### PR TITLE
docs: Workday pull-script docs + README prerequisites + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,14 @@ project/course_planner/View_My_Academic_Progress.xlsx
 project/course_planner/SCU_Find_Course_Sections.xlsx
 project/course_planner/~$*.xlsx
 
+# Workday auto-pull prototype (branch): the persistent Playwright login profile
+# (canonically project/course_planner/.workday_profile/) holds Workday cookies +
+# session — NEVER commit (security critical). The bare pattern matches the
+# profile dir at any depth as a safety net; *.xlsx.tmp covers the pull scripts'
+# atomic download/replace temp files.
+.workday_profile/
+project/course_planner/*.xlsx.tmp
+
 # Course planner local SQLite database (per-user accounts + memory).
 # Ignore the directory CONTENTS (so user data / app.db stay out of git) but
 # allow re-including specific seed/config files below.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -207,6 +207,11 @@ From `Copy of Red Team — SCU Course Planner.pdf`.
 - **Manual Academic Progress upload only**: students export "View My Academic
   Progress" from Workday as `.xlsx` / `.xlsm` and upload it with the paperclip.
   The Playwright Workday sync path and `SCU_WORKDAY_URL` env var were removed.
+  A **branch prototype** re-adds auto-pull the safe way — headed Playwright
+  **CLI** scripts where the human does SSO + Duo and we store zero credentials;
+  install + usage in
+  [`project/course_planner/scripts/README.md`](project/course_planner/scripts/README.md).
+  Trigger is CLI-only; productionizing as a browser extension is future work.
 - **Tests consolidated into `project/tests/`**: all pytest files now live in
   `project/tests/` (single CI home). The old `project/course_planner/tests/`
   directory still exists but only has non-test support files.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Memory retrieve + planning_agent (Gemini)  ←  preferences + gap + memory + pre
 Professor Agent (RMP) → React frontend (calendar / 4-year grid)
 ```
 
+### Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Python | **3.12** | matches CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)); backend + agents |
+| Node.js | **≥ 20.12** (CI uses 20.19) | frontend (Vite) |
+| npm | bundled with Node | installs frontend deps |
+
+A virtual environment is recommended for the backend
+(`python3 -m venv .venv && source .venv/bin/activate` before `pip install`).
+
 ### Run locally
 
 Backend:

--- a/project/api/main.py
+++ b/project/api/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from contextlib import asynccontextmanager
 
 # Resolve course_planner package root (sibling of this api directory).
 _API_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -28,13 +29,15 @@ from db.migrate import migrate
 from middleware.rate_limit import RateLimitExceeded
 from routers import auth, courses, diagnostics, four_year_plan, memory, plan, upload, voice
 
-app = FastAPI(title="SCU Course Planner API")
 
-
-@app.on_event("startup")
-def _migrate_database_on_startup() -> None:
-    """Render starts uvicorn directly, so the API must prepare SQLite itself."""
+@asynccontextmanager
+async def _lifespan(app: FastAPI):  # noqa: ARG001
+    """Run one-time startup work (DB migration) before the server begins serving."""
     migrate()
+    yield
+
+
+app = FastAPI(title="SCU Course Planner API", lifespan=_lifespan)
 
 
 @app.exception_handler(RateLimitExceeded)

--- a/project/course_planner/scripts/README.md
+++ b/project/course_planner/scripts/README.md
@@ -1,0 +1,101 @@
+# `project/course_planner/scripts/` — utility scripts
+
+| Script | Purpose |
+|--------|---------|
+| [`scrape_rmp_ratings.py`](scrape_rmp_ratings.py) | One-time RateMyProfessor scrape → `data/instructor_ratings.csv`. |
+| `workday_pull_progress.py` | **Workday auto-pull (branch prototype)** — pull a student's *View My Academic Progress* export. |
+| `workday_pull_sections.py` | **Workday auto-pull (branch prototype)** — pull the shared *Find Course Sections* catalog (admin). |
+
+---
+
+## Workday auto-pull (branch prototype)
+
+Two **headed** Playwright scripts that re-add automated Workday pulls **without
+ever handling SCU credentials**. A real browser window opens; **you** complete
+SSO + Duo by hand; the script automates only the steps *after* login
+(navigate → click **Export to Excel** → capture the download). A persistent,
+gitignored browser profile keeps you logged in between runs.
+
+History: an earlier headless, credential-injecting `POST /api/workday/sync`
+scraper was removed on 2026-05-23 (see [`docs/outdated-features.md`](../../../docs/outdated-features.md)).
+`playwright` was kept in `project/requirements.txt` so this safer approach could
+be re-attempted on a branch.
+
+### Prototype boundary — read first
+
+- **Trigger is a CLI command, not an in-app button.** A web page cannot launch a
+  local browser, so the student/admin runs the script from a terminal. (The
+  student still logs in themselves — the script just opens the browser for them.)
+- **Zero credential handling.** We never see, type, or store SCU passwords. The
+  only persisted state is a local login profile at
+  `project/course_planner/.workday_profile/`, which is **gitignored**.
+- **Productionization path = a browser extension** (Chrome/MV3) running in the
+  student's existing Workday tab. That is **future work, out of scope here.**
+
+### Install (from zero)
+
+```bash
+# From the repo root — installs deps incl. playwright==1.60.0
+pip install -r project/requirements.txt
+
+# One-time: download the Chromium browser Playwright drives
+playwright install chromium
+```
+
+A virtualenv is recommended (see the root [`README.md`](../../../README.md)
+"Prerequisites" — Python 3.12). Use the **same interpreter** you run the API
+with, so the in-process xlsx validation imports resolve.
+
+### Usage
+
+Run from `project/course_planner/`:
+
+```bash
+cd project/course_planner
+```
+
+#### 1. Academic progress — per student
+
+```bash
+# Default: POST the export to a running API as this user (same path as the
+# paperclip upload). The API must be up at http://localhost:8000.
+python scripts/workday_pull_progress.py --user-id <USER_ID>
+
+# Alternative: just write the .xlsx to disk, don't upload.
+python scripts/workday_pull_progress.py --save ./View_My_Academic_Progress.xlsx
+```
+
+A browser opens → log in and approve Duo. The script then exports
+*View My Academic Progress*, validates the parsed rows in-process (and aborts
+loudly if they come back empty — a sign Workday's layout changed), and either
+POSTs the bytes to `/api/upload/transcript` or saves them per `--save`.
+
+#### 2. Course sections — admin
+
+```bash
+python scripts/workday_pull_sections.py
+```
+
+Opens a browser → log in. The script exports *Find Course Sections* and
+**atomically overwrites** `project/course_planner/SCU_Find_Course_Sections.xlsx`
+(the shared catalog — identical for every student, not pulled per-user). To run
+it "on a schedule," wrap it in cron/launchd; note it still needs a valid session
+(the persistent profile) and a human re-login whenever that session expires.
+
+#### After pulling course sections: refresh the API
+
+`GET /api/courses` and the schedule indexes are cached (`lru_cache`), so a freshly
+written xlsx is **not** served until the caches clear. Either:
+
+- **Restart the API** (prototype default), or
+- `POST /api/courses/refresh` — if/once that cache-clearing endpoint is added.
+
+### The login profile (security)
+
+- The first run creates `project/course_planner/.workday_profile/`, a persistent
+  Chromium profile holding your Workday cookies/session so you don't re-login
+  every time.
+- It is **gitignored** — cookies/session/credentials must never be committed.
+  After any run, confirm `git status` shows **no** profile, cookie, or `.tmp`
+  download files.
+- Delete the directory to force a fresh login.


### PR DESCRIPTION
## Summary
- **README prerequisites**: add a Prerequisites section to the root README (Python 3.12, Node >=20.12 — matching CI) so new contributors know the required runtimes.
- **Workday auto-pull prototype (branch) — gitignore + docs**:
  - gitignore the persistent Playwright login profile (`.workday_profile/`, holds Workday cookies/session — security critical, never commit) and `*.xlsx.tmp` scratch files.
  - new `project/course_planner/scripts/README.md`: from-scratch install (`pip install -r project/requirements.txt` → `playwright install chromium`) + usage of `workday_pull_progress.py` / `workday_pull_sections.py`, the cache-refresh-after-sync note, and the CLI-trigger / browser-extension prototype boundary.
  - pointer added from HANDOFF.md §5.
- **Also carries** 2 local-only `fix(T1)` commits (deprecated `@app.on_event` → lifespan handler) that were on local `main` but not `origin/main`.

## Notes
- Merges cleanly onto `origin/main` (verified via `git merge-tree` — no conflicts).
- The Workday pull scripts themselves are a separate task/branch; this PR is the safety (gitignore) + docs groundwork for them.

## Test plan
- [ ] `git check-ignore` confirms `.workday_profile/**` + `project/course_planner/*.xlsx.tmp` are ignored; scripts/docs stay tracked.
- [ ] Root README renders the Prerequisites table.
- [ ] Existing CI suite stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)