### PR TITLE
fix(tests): stub schedule loaders in planning-agent unit tests

### DIFF
--- a/project/tests/jason/test_planning_agent_future_features_red.py
+++ b/project/tests/jason/test_planning_agent_future_features_red.py
@@ -44,15 +44,20 @@ class JasonPlanningAgentFutureFeaturesRedTests(unittest.TestCase):
         fake_client = self._fake_client_with_text(
             '{"recommended":[{"course":"CSE 130","category":"Core","units":4,"reason":"Good fit"}],"total_units":4,"advice":"Balanced plan."}'
         )
+        _sched = {("CSE", "130"): {}}
 
         with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}, clear=True):
             with patch.object(planning_agent, "get_genai_client", return_value=fake_client):
-                result = planning_agent.run_planning_agent(
-                    [{"course": "CSE 130", "category": "Core", "units": 4}],
-                    "balanced workload",
-                )
+                with patch.object(planning_agent, "load_schedule_section_index", return_value=_sched):
+                    with patch.object(planning_agent, "load_category_course_index", return_value={}):
+                        with patch.object(planning_agent, "load_course_units_index", return_value={}):
+                            with patch.object(planning_agent, "load_course_titles_index", return_value={}):
+                                result = planning_agent.run_planning_agent(
+                                    [{"course": "CSE 130", "category": "Core", "units": 4}],
+                                    "balanced workload",
+                                )
 
-        # RED target: every course recommendation should expose alternatives for swap UI.
+        # Every course recommendation must expose an alternatives list (for swap UI).
         self.assertIn("alternatives", result["recommended"][0])
         self.assertIsInstance(result["recommended"][0]["alternatives"], list)
 

--- a/project/tests/jason/test_planning_agent_provider_fallback.py
+++ b/project/tests/jason/test_planning_agent_provider_fallback.py
@@ -41,14 +41,19 @@ class JasonPlanningAgentProviderFallbackTests(unittest.TestCase):
 
         fake_client = SimpleNamespace(models=SimpleNamespace(generate_content=fake_generate_content))
 
+        _sched = {("CSE", "130"): {}}
         with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key", "GEMINI_MODEL": "primary"}, clear=True):
             with patch.object(planning_agent, "get_genai_client", return_value=fake_client):
                 with patch.object(planning_agent, "FALLBACK_MODELS", ("fallback",)):
                     with patch.object(planning_agent.time, "sleep", return_value=None):
-                        result = planning_agent.run_planning_agent(
-                            [{"course": "CSE 130", "category": "Core", "units": 4}],
-                            "balanced workload",
-                        )
+                        with patch.object(planning_agent, "load_schedule_section_index", return_value=_sched):
+                            with patch.object(planning_agent, "load_category_course_index", return_value={}):
+                                with patch.object(planning_agent, "load_course_units_index", return_value={}):
+                                    with patch.object(planning_agent, "load_course_titles_index", return_value={}):
+                                        result = planning_agent.run_planning_agent(
+                                            [{"course": "CSE 130", "category": "Core", "units": 4}],
+                                            "balanced workload",
+                                        )
 
         self.assertEqual(attempts["primary"], 3)
         self.assertEqual(call_models, ["primary", "primary", "primary", "fallback"])

--- a/project/tests/test_lab_pairing.py
+++ b/project/tests/test_lab_pairing.py
@@ -155,6 +155,9 @@ def test_run_planning_agent_auto_pairs_and_recomputes_total(monkeypatch):
         planning_agent, "load_schedule_section_index",
         lambda: _fake_schedule("CSEN 194", "CSEN 194L", "COEN 194", "COEN 194L", "PHIL 11"),
     )
+    # Prevent real xlsx unit/title overrides from changing stub values
+    monkeypatch.setattr(planning_agent, "load_course_units_index", lambda: {})
+    monkeypatch.setattr(planning_agent, "load_course_titles_index", lambda: {})
 
     out = planning_agent.run_planning_agent(
         missing_details=[
@@ -191,6 +194,9 @@ def test_run_planning_agent_does_not_pair_when_lab_not_in_gap(monkeypatch):
         planning_agent, "load_schedule_section_index",
         lambda: _fake_schedule("CSEN 194", "COEN 194"),
     )
+    # Prevent real xlsx unit/title overrides from changing stub values
+    monkeypatch.setattr(planning_agent, "load_course_units_index", lambda: {})
+    monkeypatch.setattr(planning_agent, "load_course_titles_index", lambda: {})
 
     out = planning_agent.run_planning_agent(
         missing_details=[

--- a/project/tests/test_orchestrator_injection.py
+++ b/project/tests/test_orchestrator_injection.py
@@ -113,6 +113,10 @@ def test_prompt_prefix_respects_char_budget(monkeypatch, alice, reply):
 
     captured: list[str] = []
     _patch_client(monkeypatch, captured, reply)
+    # Use empty schedule so the schedule block does not appear between the
+    # memory block and "STUDENT REQUIREMENTS" and inflate the measurement.
+    monkeypatch.setattr(planning_agent, "load_schedule_section_index", lambda: {})
+    monkeypatch.setattr(planning_agent, "load_category_course_index", lambda: {})
 
     orchestrator.plan_for_user(
         alice,
@@ -154,6 +158,9 @@ def test_oversized_single_snippet_drops_block_gracefully(monkeypatch, alice, rep
 def test_no_injection_block_when_no_memory(monkeypatch, alice, reply):
     captured: list[str] = []
     _patch_client(monkeypatch, captured, reply)
+    # Empty schedule so the prompt has no schedule block between memory and STUDENT REQUIREMENTS.
+    monkeypatch.setattr(planning_agent, "load_schedule_section_index", lambda: {})
+    monkeypatch.setattr(planning_agent, "load_category_course_index", lambda: {})
 
     orchestrator.plan_for_user(
         alice,


### PR DESCRIPTION
## Summary
- Make the planning-agent unit tests **hermetic**: stub the xlsx-backed index loaders (`load_schedule_section_index`, `load_category_course_index`, `load_course_units_index`, `load_course_titles_index`) so the tests no longer depend on the real `SCU_Find_Course_Sections.xlsx`.
- `test_planning_agent_future_features_red` / `test_planning_agent_provider_fallback`: wrap the `run_planning_agent` call with the loader stubs.
- `test_lab_pairing`: stub units/titles indexes so real xlsx overrides don't change the stubbed values.
- `test_orchestrator_injection`: use an empty schedule so the schedule block doesn't sit between the memory block and STUDENT REQUIREMENTS and inflate the char-budget measurement.

## Test plan
- [ ] CI (`test`) green for the 4 affected test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)