### PR TITLE
feat(workday): headed Playwright pull scripts + POST /api/courses/refresh

### DIFF
--- a/project/api/routers/courses.py
+++ b/project/api/routers/courses.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from fastapi import APIRouter
 
-from utils.scu_course_schedule_xlsx import list_offered_courses
+from utils.scu_course_schedule_xlsx import clear_schedule_caches, list_offered_courses
 
 router = APIRouter()
 
@@ -31,3 +31,12 @@ def _cached_courses() -> list[dict[str, Any]]:
 def get_courses() -> dict[str, Any]:
     courses = _cached_courses()
     return {"courses": courses, "count": len(courses)}
+
+
+@router.post("/refresh")
+def refresh_courses() -> dict[str, Any]:
+    """Clear schedule caches so the next ``GET /api/courses`` reads the on-disk xlsx."""
+    clear_schedule_caches()
+    _cached_courses.cache_clear()
+    courses = _cached_courses()
+    return {"ok": True, "count": len(courses)}

--- a/project/course_planner/scripts/README.md
+++ b/project/course_planner/scripts/README.md
@@ -88,7 +88,7 @@ it "on a schedule," wrap it in cron/launchd; note it still needs a valid session
 written xlsx is **not** served until the caches clear. Either:
 
 - **Restart the API** (prototype default), or
-- `POST /api/courses/refresh` — if/once that cache-clearing endpoint is added.
+- `POST /api/courses/refresh` — clears schedule ``lru_cache`` + ``GET /api/courses`` cache.
 
 ### The login profile (security)
 

--- a/project/course_planner/scripts/_workday_browser.py
+++ b/project/course_planner/scripts/_workday_browser.py
@@ -1,0 +1,304 @@
+"""
+Shared Playwright browser helper for the headed, human-authenticated Workday
+pull scripts (``workday_pull_progress.py`` / ``workday_pull_sections.py``).
+
+Safety model — the deliberate opposite of the removed ``c095321`` scraper:
+
+  * **Headed** (visible) Chromium, never headless.
+  * **The human logs in** — SSO + Duo MFA happen in the real browser window;
+    this module never sees, asks for, or stores SCU credentials.
+  * **Persistent profile** keeps the Workday session across runs (cookies live
+    in a local, gitignored profile dir — never SCU passwords).
+  * **No DOM scraping** of academic data: we click Workday's native
+    *Export to Excel* control and capture the downloaded ``.xlsx`` bytes, which
+    the existing parsers already understand.
+
+Public API (the two pull scripts depend on these signatures)::
+
+    context, page = launch(profile_dir)
+    wait_for_login(page)                       # blocks until the human is in
+    data = export_to_excel(page, navigate)     # navigate(page) -> task page
+
+Selector lists are recovered from the removed ``utils/workday_scraper.py``
+(``git show c095321``; export detection hardened in ``220e63a``).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from playwright.sync_api import (
+    BrowserContext,
+    Page,
+    TimeoutError as PWTimeout,
+    sync_playwright,
+)
+
+__all__ = ["launch", "wait_for_login", "export_to_excel"]
+
+# ── Config ──────────────────────────────────────────────────────────────────
+
+# Landing URL. Hitting the SCU tenant while unauthenticated triggers the
+# Workday → SSO redirect, which is exactly the login flow we want the human to
+# complete in the visible window.
+WORKDAY_HOME = "https://www.myworkday.com/scu/d/home.htmld"
+
+# The ``/scu`` tenant path disambiguates our Workday from every other customer.
+WORKDAY_BASE = "myworkday.com/scu"
+
+# Substrings that mark a mid-flight SSO/MFA page. SCU funnels login through
+# Shibboleth + Microsoft (Duo), so a URL containing any of these means "still
+# logging in" — even when the host is myworkday.com.
+SSO_KEYWORDS = (
+    "login", "sso", "saml", "oauth", "auth", "signin",
+    "adfs", "okta", "microsoftonline", "shibboleth", "duosecurity", "duo",
+)
+
+NAV_TIMEOUT_MS = 60 * 1000
+DL_TIMEOUT_MS = 90 * 1000
+RENDER_WAIT_MS = 4_000  # fixed pause after navigation for the SPA to paint
+
+_LOGIN_PROMPT = (
+    "\n"
+    "============================================================\n"
+    " A Workday window just opened.\n"
+    " Please LOG IN and approve the Duo (MFA) prompt in that window.\n"
+    " This tool never sees your password — you authenticate yourself.\n"
+    " Waiting for login to complete...\n"
+    "============================================================\n"
+)
+
+
+# ── Page classification (login detection — URL only, no DOM scraping) ────────
+
+def _on_sso_page(page: Page) -> bool:
+    return any(kw in page.url.lower() for kw in SSO_KEYWORDS)
+
+
+def _on_workday(page: Page) -> bool:
+    return WORKDAY_BASE in page.url.lower() and not _on_sso_page(page)
+
+
+def _active_workday_page(initial: Page) -> Page | None:
+    """Return whichever tab in the context is on Workday (past SSO), or None.
+
+    SSO can land the post-login session in a new tab, so we scan every page in
+    the context rather than only the one we opened.
+    """
+    try:
+        for p in initial.context.pages:
+            if _on_workday(p):
+                return p
+    except Exception:  # noqa: BLE001 — closed/degenerate page → fall through
+        pass
+    return initial if _on_workday(initial) else None
+
+
+def _wait_for_render(page: Page) -> None:
+    """Wait for Workday content to paint.
+
+    ``networkidle`` never fires on Workday (the SPA polls forever), so we wait
+    for ``domcontentloaded`` plus a short fixed pause instead.
+    """
+    try:
+        page.wait_for_load_state("domcontentloaded", timeout=30_000)
+    except PWTimeout:
+        pass
+    page.wait_for_timeout(RENDER_WAIT_MS)
+
+
+# ── Public: launch ───────────────────────────────────────────────────────────
+
+def launch(profile_dir: str | Path) -> tuple[BrowserContext, Page]:
+    """Open a headed Chromium with a persistent profile, parked on Workday.
+
+    Uses ``launch_persistent_context`` so the Workday session (cookies) survives
+    between runs — only the cookies, never credentials. ``profile_dir`` is
+    created on first run. Returns ``(context, page)``; the caller is responsible
+    for ``context.close()`` when done.
+    """
+    profile_path = Path(profile_dir)
+    profile_path.mkdir(parents=True, exist_ok=True)  # first run creates it
+
+    pw = sync_playwright().start()
+    context = pw.chromium.launch_persistent_context(
+        user_data_dir=str(profile_path),
+        headless=False,            # never headless — the human must see + log in
+        accept_downloads=True,     # required to capture the Export-to-Excel file
+        no_viewport=True,
+        args=["--start-maximized"],
+    )
+    # Keep the driver alive for the context's lifetime (caller closes context).
+    context._playwright = pw  # type: ignore[attr-defined]
+
+    page = context.pages[0] if context.pages else context.new_page()
+    try:
+        page.goto(WORKDAY_HOME, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
+    except Exception:  # noqa: BLE001 — SSO redirect may interrupt load; that's fine
+        pass
+    return context, page
+
+
+# ── Public: wait_for_login ───────────────────────────────────────────────────
+
+def wait_for_login(page: Page, *, timeout_s: int = 300) -> None:
+    """Block until the human has completed SSO + Duo and Workday is loaded.
+
+    Polls the browser (URL only — no DOM scraping) until a tab is back on the
+    Workday tenant and off every SSO/MFA host. Prints a clear prompt telling the
+    user to log in. Raises ``TimeoutError`` after ``timeout_s`` seconds.
+    """
+    print(_LOGIN_PROMPT, flush=True)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _active_workday_page(page) is not None:
+            print("Workday login detected — continuing.\n", flush=True)
+            return
+        time.sleep(2.0)
+    raise TimeoutError(
+        f"Login not completed within {timeout_s}s. Re-run and finish the SSO + "
+        "Duo prompt in the opened window. If it keeps failing, fall back to the "
+        "manual xlsx upload via the paperclip button in the app."
+    )
+
+
+# ── Export-to-Excel (native download capture — never DOM scraping) ───────────
+
+# Strategy 1: a direct export/Excel button.
+_DIRECT_EXPORT_SELECTORS = (
+    '[data-automation-id="excelButton"]',
+    '[data-automation-id="spreadsheetButton"]',
+    '[data-automation-id="exportButton"]',
+    '[data-automation-id="viewAllExcelButton"]',
+    'button[aria-label*="Excel" i]',
+    'button[aria-label*="Export to Excel" i]',
+    'button[aria-label*="Export to Spreadsheet" i]',
+    'button:has-text("Export to Excel")',
+    'button:has-text("Excel")',
+)
+
+# Strategy 2: open an Actions / gear menu, then click the Excel item.
+_ACTION_OPENERS = (
+    '[data-automation-id="actions"]',
+    '[data-automation-id="wd-CommandBar-button-exportButton"]',
+    'button[aria-label*="Actions" i]',
+    'button[aria-label*="More options" i]',
+    '[aria-label*="Export" i]',
+)
+_EXCEL_MENU_ITEMS = (
+    '[data-automation-id*="excel" i]',
+    '[role="menuitem"]:has-text("Excel")',
+    '[role="option"]:has-text("Excel")',
+    'li:has-text("Export to Excel")',
+    'li:has-text("Excel")',
+)
+
+# Strategy 3: enumerate buttons/links and find one that mentions Excel/Export.
+# This locates the *export control* — it does not read any academic data.
+_DISCOVER_JS = """
+() => {
+    const out = [];
+    for (const n of document.querySelectorAll('button, [role="button"], a')) {
+        const text  = (n.textContent || '').trim().toLowerCase();
+        const label = (n.getAttribute('aria-label') || '').toLowerCase();
+        const aid   = (n.getAttribute('data-automation-id') || '').toLowerCase();
+        if (text.includes('excel') || text.includes('export') ||
+            label.includes('excel') || label.includes('export') ||
+            aid.includes('excel') || aid.includes('export')) {
+            out.push({ text, label, aid });
+        }
+    }
+    return out.slice(0, 5);
+}
+"""
+
+
+def _download_by_selector(page: Page, selector: str, *, timeout: int = 4_000) -> bytes | None:
+    """Click ``selector`` and capture the resulting download as bytes, or None."""
+    try:
+        page.wait_for_selector(selector, timeout=timeout, state="visible")
+        with page.expect_download(timeout=DL_TIMEOUT_MS) as dl_info:
+            page.click(selector, timeout=timeout)
+        path = dl_info.value.path()
+        return Path(path).read_bytes() if path else None
+    except Exception:  # noqa: BLE001 — selector absent / no download → try next
+        return None
+
+
+def _download_via_direct(page: Page) -> bytes | None:
+    for sel in _DIRECT_EXPORT_SELECTORS:
+        data = _download_by_selector(page, sel)
+        if data:
+            return data
+    return None
+
+
+def _download_via_menu(page: Page) -> bytes | None:
+    for opener in _ACTION_OPENERS:
+        try:
+            page.click(opener, timeout=3_000)
+            page.wait_for_timeout(600)
+            for item in _EXCEL_MENU_ITEMS:
+                data = _download_by_selector(page, item, timeout=3_000)
+                if data:
+                    return data
+            page.keyboard.press("Escape")  # close menu before trying next opener
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+def _download_via_js(page: Page) -> bytes | None:
+    try:
+        candidates = page.evaluate(_DISCOVER_JS)
+    except Exception:  # noqa: BLE001
+        return None
+    for cand in candidates or []:
+        if cand.get("aid"):
+            sel = f'[data-automation-id="{cand["aid"]}"]'
+        elif cand.get("label"):
+            sel = f'[aria-label="{cand["label"]}"]'
+        elif cand.get("text"):
+            sel = f'button:has-text("{cand["text"][:30]}")'
+        else:
+            continue
+        data = _download_by_selector(page, sel)
+        if data:
+            return data
+    return None
+
+
+def export_to_excel(page: Page, navigate: Callable[[Page], None]) -> bytes:
+    """Navigate to the target task page, click *Export to Excel*, return bytes.
+
+    ``navigate(page)`` is a caller-supplied callback that drives ``page`` to the
+    specific Workday report (e.g. View My Academic Progress / Find Course
+    Sections). We then trigger Workday's native Excel export and capture the
+    downloaded file — we never scrape the rendered table.
+
+    Raises ``RuntimeError`` if no export control can be found (a strong signal
+    that the Workday layout changed) — callers should abort loudly rather than
+    write garbage.
+    """
+    navigate(page)
+    _wait_for_render(page)
+
+    for strategy in (_download_via_direct, _download_via_menu, _download_via_js):
+        data = strategy(page)
+        if data:
+            return data
+
+    hint = ""
+    try:
+        shot = Path(tempfile.gettempdir()) / "workday_export_debug.png"
+        page.screenshot(path=str(shot), full_page=False)
+        hint = f" (debug screenshot: {shot})"
+    except Exception:  # noqa: BLE001
+        pass
+    raise RuntimeError(
+        "Could not find Workday's 'Export to Excel' control on the report page. "
+        "The Workday layout may have changed — aborting instead of guessing." + hint
+    )

--- a/project/course_planner/scripts/validate_workday_e2e.py
+++ b/project/course_planner/scripts/validate_workday_e2e.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Automated checks for Workday pull E2E (no Duo). Live browser tests are separate.
+
+Run from project/course_planner/::
+
+    python scripts/validate_workday_e2e.py
+
+Exits 0 when all automated checks pass; prints a checklist for human Duo steps.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_CWD = Path.cwd()
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+REPO_ROOT = _ROOT.parent.parent
+SAMPLE_PROGRESS = _ROOT / "View_My_Academic_Progress.xlsx"
+SAMPLE_SECTIONS = _ROOT / "SCU_Find_Course_Sections.xlsx"
+PROFILE = _ROOT / ".workday_profile"
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> tuple[int, str]:
+    p = subprocess.run(
+        cmd,
+        cwd=cwd or REPO_ROOT / "project",
+        capture_output=True,
+        text=True,
+    )
+    out = (p.stdout or "") + (p.stderr or "")
+    return p.returncode, out
+
+
+def check_gitignore_security() -> bool:
+    print("\n[4] Security: git status must not list profile/cookies")
+    r = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    lines = [ln for ln in (r.stdout or "").splitlines() if ln.strip()]
+    bad = [
+        ln
+        for ln in lines
+        if any(
+            x in ln.lower()
+            for x in (
+                ".workday_profile",
+                "cookies",
+                "credentials",
+                ".env",
+            )
+        )
+        and "??" not in ln or ".workday_profile" in ln
+    ]
+    # Untracked .workday_profile is OK if gitignored; verify ignore
+    check = subprocess.run(
+        ["git", "check-ignore", "-v", str(PROFILE)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    ignored = check.returncode == 0
+    print(f"    .workday_profile gitignored: {ignored}")
+    if bad:
+        print("    FAIL staged/modified sensitive paths:")
+        for ln in bad:
+            print(f"      {ln}")
+        return False
+    print("    PASS (no profile/credentials in tracked changes)")
+    return ignored
+
+
+def check_unit_tests() -> bool:
+    print("\n[unit] pytest workday + courses refresh")
+    code, out = _run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_workday_browser_scripts.py",
+            "tests/test_workday_pull_progress.py",
+            "tests/test_workday_pull_sections.py",
+            "tests/test_courses_refresh.py",
+            "-q",
+        ],
+    )
+    print(out[-2000:] if len(out) > 2000 else out)
+    return code == 0
+
+
+def check_sample_upload_parity(api_base: str) -> bool:
+    print("\n[1-partial] Sample xlsx vs parse (no Workday browser)")
+    if not SAMPLE_PROGRESS.is_file():
+        print(f"    SKIP — missing {SAMPLE_PROGRESS.name} (gitignored sample)")
+        return True
+    from utils.academic_progress_xlsx import parse_academic_progress_xlsx, sanitize_parsed_rows
+    from utils.academic_progress_helpers import enrich_missing_details
+
+    raw = SAMPLE_PROGRESS.read_bytes()
+    data = parse_academic_progress_xlsx(raw)
+    detail = data.get("detail_rows") or []
+    not_sat = data.get("not_satisfied") or []
+    if not detail and not not_sat:
+        print("    FAIL sample parses empty")
+        return False
+    parsed_rows = sanitize_parsed_rows(detail)
+    missing = enrich_missing_details(not_sat, parsed_rows)
+    print(f"    parse: detail_rows={len(detail)} not_satisfied={len(not_sat)}")
+    try:
+        import requests
+
+        files = {
+            "file": (SAMPLE_PROGRESS.name, raw, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        }
+        uid = os.environ.get("WORKDAY_E2E_USER_ID", "e2e-test-user")
+        resp = requests.post(
+            f"{api_base}/api/upload/transcript",
+            files=files,
+            data={"user_id": uid},
+            timeout=30,
+        )
+        if resp.status_code != 200:
+            print(f"    SKIP API upload — status {resp.status_code} (is API running?)")
+            return True
+        body = resp.json()
+        print(
+            f"    API: missing_details={len(body.get('missing_details') or [])} "
+            f"parsed_rows={len(body.get('parsed_rows') or [])}"
+        )
+        return bool(body.get("parsed_rows"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"    SKIP API — {exc}")
+        return True
+
+
+def check_sections_catalog() -> bool:
+    print("\n[2-partial] Sections xlsx on disk")
+    if not SAMPLE_SECTIONS.is_file():
+        print(f"    SKIP — missing {SAMPLE_SECTIONS.name}")
+        return True
+    from utils.scu_course_schedule_xlsx import list_offered_courses
+
+    n = len(list_offered_courses(SAMPLE_SECTIONS))
+    mtime = SAMPLE_SECTIONS.stat().st_mtime
+    print(f"    courses={n} mtime={mtime}")
+    return n > 0
+
+
+def check_robustness_empty_parse() -> bool:
+    print("\n[3] Robustness: empty xlsx aborts validation")
+    from io import BytesIO
+
+    from openpyxl import Workbook
+    from scripts import workday_pull_progress as wpp
+
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Requirement", "Status", "Remaining", "Registration", "Period", "Units", "Grade"])
+    buf = BytesIO()
+    wb.save(buf)
+    try:
+        wpp.validate_progress_export(buf.getvalue())
+        print("    FAIL should have raised")
+        return False
+    except wpp.ProgressValidationError as exc:
+        print(f"    PASS ProgressValidationError: {str(exc)[:80]}...")
+        return True
+
+
+def print_human_checklist() -> None:
+    print(
+        """
+============================================================
+ HUMAN STEPS (require Duo in headed browser)
+============================================================
+1. Start API:  cd project/api && uvicorn main:app --reload --port 8000
+2. Progress:   cd project/course_planner
+               python scripts/workday_pull_progress.py --user-id <USER_ID>
+               → login + Duo → expect non-zero missing_details / parsed_rows
+3. Sections:   python scripts/workday_pull_sections.py
+               → login → SCU_Find_Course_Sections.xlsx new mtime
+               curl -X POST http://localhost:8000/api/courses/refresh
+4. Wrong page: SCU_WORKDAY_URL=https://www.myworkday.com/scu/d/home.htmld \\
+               python scripts/workday_pull_progress.py --save /tmp/bad.xlsx
+               → must exit 1 or 2 with clear error, no /tmp/bad.xlsx or empty file
+============================================================
+"""
+    )
+
+
+def main() -> int:
+    api = os.environ.get("WORKDAY_E2E_API", "http://localhost:8000")
+    ok = True
+    ok &= check_unit_tests()
+    ok &= check_robustness_empty_parse()
+    ok &= check_sample_upload_parity(api)
+    ok &= check_sections_catalog()
+    ok &= check_gitignore_security()
+    print_human_checklist()
+    print("Automated checks:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/project/course_planner/scripts/workday_pull_progress.py
+++ b/project/course_planner/scripts/workday_pull_progress.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Pull *View My Academic Progress* from Workday and upload or save the export.
+
+Run from ``project/course_planner/`` (see ``scripts/README.md``).
+
+Flow
+----
+1. Open a **headed** Chromium with a persistent profile (``.workday_profile/``).
+2. **You** complete SCU SSO + Duo in that window — this script never sees credentials.
+3. Navigate to *View My Academic Progress*, click Workday's native **Export to Excel**.
+4. Validate the download in-process; abort loudly if parsing yields no rows.
+5. Either POST to the local API (``--user-id``) or write the ``.xlsx`` (``--save``).
+
+Exit codes
+----------
+* ``0`` — success
+* ``1`` — validation failed or API upload failed
+* ``2`` — browser launch, login timeout, navigation, or export failed
+
+Cron / automation
+-----------------
+Everything after login is automatable. The first run (or after session expiry) still
+requires a human at the keyboard for SSO + Duo. Keep the API running for POST mode.
+
+Environment
+-----------
+* ``SCU_WORKDAY_URL`` — override the default Academic Progress task URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Locate course_planner root (same pattern as scrape_rmp_ratings.py).
+_CWD = Path.cwd()
+_SCRIPT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _find_root() -> Path:
+    for candidate in (_CWD, _SCRIPT_ROOT):
+        if (candidate / "utils").is_dir() and (candidate / "scripts").is_dir():
+            return candidate
+    for parent in _CWD.parents:
+        cp = parent / "course_planner"
+        if (cp / "utils").is_dir():
+            return cp
+    raise FileNotFoundError(
+        "Cannot find course_planner root. Run from project/course_planner/."
+    )
+
+
+_HERE = _find_root()
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from playwright.sync_api import Page, TimeoutError as PWTimeout  # noqa: E402
+
+from scripts._workday_browser import export_to_excel, launch, wait_for_login  # noqa: E402
+from utils.academic_progress_helpers import enrich_missing_details  # noqa: E402
+from utils.academic_progress_xlsx import parse_academic_progress_xlsx  # noqa: E402
+
+# ── Config ───────────────────────────────────────────────────────────────────
+
+TASK_URL = os.environ.get(
+    "SCU_WORKDAY_URL",
+    "https://www.myworkday.com/scu/d/task/2998$44123.htmld",
+)
+DEFAULT_PROFILE_DIR = _HERE / ".workday_profile"
+DEFAULT_UPLOAD_URL = "http://localhost:8000/api/upload/transcript"
+
+NAV_TIMEOUT_MS = 60 * 1000
+RENDER_WAIT_MS = 4_000
+
+_ACADEMIC_PROGRESS_HEADINGS = (
+    "view my academic progress",
+    "academic progress",
+    "my academic progress",
+)
+_SEARCH_QUERY = "View My Academic Progress"
+
+
+class ProgressValidationError(Exception):
+    """Parsed Workday export is empty — layout likely changed."""
+
+
+# ── Navigation (recovered from utils/workday_scraper.py @ c095321^) ───────────
+
+
+def _wait_for_workday_content(page: Page) -> None:
+    try:
+        page.wait_for_load_state("domcontentloaded", timeout=30_000)
+    except PWTimeout:
+        pass
+    page.wait_for_timeout(RENDER_WAIT_MS)
+
+
+def _on_academic_progress_page(page: Page) -> bool:
+    try:
+        title = (page.title() or "").lower()
+        if any(h in title for h in _ACADEMIC_PROGRESS_HEADINGS):
+            return True
+        heading = page.evaluate(
+            "() => (document.querySelector('h1, [role=\"heading\"]') || {}).textContent || ''"
+        )
+        return any(h in str(heading).lower() for h in _ACADEMIC_PROGRESS_HEADINGS)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _try_search_for_report(page: Page) -> bool:
+    search_box_selectors = [
+        '[data-automation-id="globalSearchBox"]',
+        '[data-automation-id="searchBox"]',
+        '[data-automation-id="GLOBAL_SEARCH_BOX"]',
+        'input[aria-label*="Search" i]',
+        'input[placeholder*="Search" i]',
+    ]
+    box = None
+    for sel in search_box_selectors:
+        try:
+            page.wait_for_selector(sel, timeout=4_000, state="visible")
+            box = page.locator(sel).first
+            box.click()
+            break
+        except Exception:  # noqa: BLE001
+            box = None
+            continue
+    if box is None:
+        return False
+
+    try:
+        box.fill(_SEARCH_QUERY)
+        page.wait_for_timeout(1_500)
+        suggestion_selectors = [
+            f'text="{_SEARCH_QUERY}"',
+            'text="View My Academic Progress"',
+            'a:has-text("View My Academic Progress")',
+            '[data-automation-id="searchResults"] a',
+        ]
+        for sel in suggestion_selectors:
+            try:
+                page.locator(sel).first.click(timeout=3_000)
+                _wait_for_workday_content(page)
+                if _on_academic_progress_page(page):
+                    return True
+            except Exception:  # noqa: BLE001
+                continue
+        page.keyboard.press("Enter")
+        _wait_for_workday_content(page)
+        return _on_academic_progress_page(page)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _ensure_on_task(page: Page, task_url: str = TASK_URL) -> None:
+    """Navigate to View My Academic Progress (direct URL, then search fallback)."""
+    task_path = task_url.split("/scu/", 1)[-1].split("?")[0].lower()
+
+    _wait_for_workday_content(page)
+    if _on_academic_progress_page(page):
+        return
+
+    if task_path not in page.url.lower():
+        try:
+            page.goto(task_url, timeout=NAV_TIMEOUT_MS, wait_until="domcontentloaded")
+            _wait_for_workday_content(page)
+        except Exception:  # noqa: BLE001
+            pass
+        if _on_academic_progress_page(page):
+            return
+
+    if _try_search_for_report(page):
+        return
+
+    actual = ""
+    try:
+        actual = (page.title() or "").strip()
+    except Exception:  # noqa: BLE001
+        pass
+    raise RuntimeError(
+        "Could not reach 'View My Academic Progress' in Workday"
+        + (f" — currently on {actual!r}." if actual else ".")
+        + "\nThe SCU_WORKDAY_URL task ID may be stale and the search fallback failed. "
+        "Workaround: export manually in Workday and upload via the paperclip in the app."
+    )
+
+
+def navigate_to_academic_progress(page: Page) -> None:
+    """``navigate`` callback for ``export_to_excel``."""
+    _ensure_on_task(page)
+
+
+# ── Validation & upload ───────────────────────────────────────────────────────
+
+
+def validate_progress_export(xlsx_bytes: bytes) -> dict[str, Any]:
+    """Parse export bytes; raise if both ``detail_rows`` and ``not_satisfied`` are empty."""
+    data = parse_academic_progress_xlsx(xlsx_bytes)
+    detail_rows = data.get("detail_rows") or []
+    not_satisfied = data.get("not_satisfied") or []
+    if not detail_rows and not not_satisfied:
+        raise ProgressValidationError(
+            "Workday export parsed to ZERO rows (detail_rows and not_satisfied both empty).\n"
+            "The Academic Progress Excel layout may have changed — NOT writing or uploading "
+            "this file. Re-export manually or update the parser."
+        )
+    return data
+
+
+def _post_transcript(
+    xlsx_bytes: bytes,
+    *,
+    user_id: str,
+    upload_url: str = DEFAULT_UPLOAD_URL,
+) -> dict[str, Any]:
+    import requests
+
+    files = {
+        "file": (
+            "academic_progress.xlsx",
+            xlsx_bytes,
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ),
+    }
+    data = {"user_id": user_id}
+    resp = requests.post(upload_url, files=files, data=data, timeout=120)
+    resp.raise_for_status()
+    body = resp.json()
+    if not isinstance(body, dict):
+        raise RuntimeError(f"Unexpected API response type: {type(body)!r}")
+    return body
+
+
+def _print_upload_summary(body: dict[str, Any], parsed: dict[str, Any]) -> None:
+    missing = body.get("missing_details")
+    if missing is None:
+        detail_rows = parsed.get("detail_rows") or []
+        not_satisfied = parsed.get("not_satisfied") or []
+        missing = enrich_missing_details(not_satisfied, detail_rows)
+    parsed_rows = body.get("parsed_rows") or []
+    print(f"missing_details: {len(missing)}")
+    print(f"parsed_rows: {len(parsed_rows)}")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Pull View My Academic Progress from Workday (headed browser, human login).",
+    )
+    p.add_argument(
+        "--user-id",
+        metavar="ID",
+        help="User id for POST /api/upload/transcript (required unless --save).",
+    )
+    p.add_argument(
+        "--save",
+        metavar="PATH",
+        type=Path,
+        help="Write the .xlsx to PATH instead of uploading.",
+    )
+    p.add_argument(
+        "--profile-dir",
+        type=Path,
+        default=DEFAULT_PROFILE_DIR,
+        help=f"Persistent Chromium profile (default: {DEFAULT_PROFILE_DIR}).",
+    )
+    p.add_argument(
+        "--upload-url",
+        default=DEFAULT_UPLOAD_URL,
+        help=f"Upload endpoint (default: {DEFAULT_UPLOAD_URL}).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.save:
+        do_upload = False
+    elif args.user_id:
+        do_upload = True
+    else:
+        _build_parser().error("one of --user-id or --save is required")
+
+    context = None
+    try:
+        context, page = launch(args.profile_dir)
+        wait_for_login(page)
+        xlsx_bytes = export_to_excel(page, navigate_to_academic_progress)
+    except TimeoutError as exc:
+        print(f"ERROR (login): {exc}", file=sys.stderr)
+        return 2
+    except RuntimeError as exc:
+        print(f"ERROR (browser/export): {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # noqa: BLE001 — Playwright / launch failures
+        print(f"ERROR (browser): {exc}", file=sys.stderr)
+        return 2
+    finally:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    try:
+        parsed = validate_progress_export(xlsx_bytes)
+    except ProgressValidationError as exc:
+        print(f"\n{'=' * 60}\nVALIDATION FAILED\n{'=' * 60}", file=sys.stderr)
+        print(str(exc), file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR (parse): {exc}", file=sys.stderr)
+        return 1
+
+    if args.save:
+        out = args.save.expanduser().resolve()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(xlsx_bytes)
+        print(f"Saved {len(xlsx_bytes)} bytes → {out}")
+        print(
+            f"parsed: detail_rows={len(parsed.get('detail_rows') or [])}, "
+            f"not_satisfied={len(parsed.get('not_satisfied') or [])}"
+        )
+        return 0
+
+    try:
+        body = _post_transcript(
+            xlsx_bytes,
+            user_id=args.user_id.strip(),
+            upload_url=args.upload_url,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR (upload): {exc}", file=sys.stderr)
+        return 1
+
+    _print_upload_summary(body, parsed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/project/course_planner/scripts/workday_pull_sections.py
+++ b/project/course_planner/scripts/workday_pull_sections.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Admin CLI: refresh the shared next-term *Find Course Sections* catalog.
+
+Opens a **headed** Chromium window; a human completes SCU SSO + Duo. The script
+then navigates to Find Course Sections, applies term/level filters, exports to
+Excel, validates the download, and atomically overwrites
+``SCU_Find_Course_Sections.xlsx``.
+
+Usage (from ``project/course_planner/``)::
+
+    python scripts/workday_pull_sections.py
+    python scripts/workday_pull_sections.py --term "Fall 2026" --level Undergraduate
+
+Environment (optional)::
+
+    SCU_WORKDAY_SECTIONS_URL  direct Workday task URL (skips global search)
+    SCU_WORKDAY_TERM          default --term when flag omitted
+    SCU_WORKDAY_LEVEL         default --level when flag omitted
+
+After a successful run, restart the API or call ``POST /api/courses/refresh``
+so ``lru_cache`` schedule indexes pick up the new xlsx (see scripts/README.md).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+# ── course_planner root on sys.path (same pattern as scrape_rmp_ratings.py) ───
+
+_CWD = Path.cwd()
+_SCRIPT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def find_course_planner_root() -> Path:
+    """Return the course_planner/ directory (may not yet contain the xlsx)."""
+    marker = "SCU_Find_Course_Sections.xlsx"
+    for candidate in (_CWD, _SCRIPT_ROOT):
+        if candidate.name == "course_planner" or (candidate / marker).is_file():
+            return candidate if candidate.name == "course_planner" else candidate
+        cp = candidate / "course_planner"
+        if cp.is_dir():
+            return cp
+    for parent in _CWD.parents:
+        cp = parent / "course_planner"
+        if cp.is_dir() and (cp / "scripts" / "workday_pull_sections.py").is_file():
+            return cp
+    if _SCRIPT_ROOT.is_dir():
+        return _SCRIPT_ROOT
+    raise FileNotFoundError(
+        "Cannot locate project/course_planner/. "
+        "Run this script from project/course_planner/."
+    )
+
+
+_HERE = find_course_planner_root()
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from scripts import _workday_browser as wb  # noqa: E402
+from utils.scu_course_schedule_xlsx import list_offered_courses  # noqa: E402
+
+# ── Paths & exit codes (cron-friendly) ───────────────────────────────────────
+
+PROFILE_DIR = _HERE / ".workday_profile"
+DEST_XLSX = _HERE / "SCU_Find_Course_Sections.xlsx"
+
+EXIT_OK = 0
+EXIT_USAGE = 1
+EXIT_LOGIN = 2
+EXIT_NAVIGATION = 3
+EXIT_EXPORT = 4
+EXIT_VALIDATION = 5
+EXIT_WRITE = 6
+
+_SECTIONS_URL_ENV = "SCU_WORKDAY_SECTIONS_URL"
+_TERM_ENV = "SCU_WORKDAY_TERM"
+_LEVEL_ENV = "SCU_WORKDAY_LEVEL"
+
+_SEARCH_QUERY = "Find Course Sections"
+_SECTIONS_HEADINGS = (
+    "find course sections",
+    "course sections",
+)
+
+# Global search box — Workday has renamed these across UI refreshes (fragile).
+_SEARCH_BOX_SELECTORS = (
+    '[data-automation-id="globalSearchBox"]',
+    '[data-automation-id="searchBox"]',
+    '[data-automation-id="GLOBAL_SEARCH_BOX"]',
+    'input[aria-label*="Search" i]',
+    'input[placeholder*="Search" i]',
+)
+
+_SEARCH_SUGGESTION_SELECTORS = (
+    f'text="{_SEARCH_QUERY}"',
+    'text="Find Course Sections"',
+    'a:has-text("Find Course Sections")',
+    '[data-automation-id="searchResults"] a',
+)
+
+# Term / level filters — layout-specific; see navigate_find_course_sections().
+_TERM_FILTER_LABELS = (
+    "academic period",
+    "academic periods",
+    "term",
+    "period",
+    "quarter",
+)
+_LEVEL_FILTER_LABELS = (
+    "academic level",
+    "level",
+    "student level",
+)
+_SEARCH_RUN_SELECTORS = (
+    '[data-automation-id="searchButton"]',
+    '[data-automation-id="submitButton"]',
+    'button:has-text("Search")',
+    'button:has-text("Go")',
+    'button:has-text("Find")',
+)
+
+
+class SectionsValidationError(RuntimeError):
+    """Downloaded xlsx parsed to zero offered courses."""
+
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+
+
+def default_term_name(today: date | None = None) -> str:
+    """Heuristic next SCU quarter when README/HANDOFF do not pin a term."""
+    d = today or date.today()
+    y, m = d.year, d.month
+    if m <= 3:
+        return f"Spring {y}"
+    if m <= 8:
+        return f"Fall {y}"
+    return f"Winter {y + 1}"
+
+
+def default_academic_level() -> str:
+    return os.environ.get(_LEVEL_ENV, "Undergraduate").strip() or "Undergraduate"
+
+
+# ── Atomic write & validation (unit-tested) ──────────────────────────────────
+
+
+def atomic_write_xlsx(dest: Path, data: bytes) -> None:
+    """Write ``dest`` via a sibling ``.tmp`` file and ``os.replace``."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    try:
+        tmp.write_bytes(data)
+        os.replace(tmp, dest)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def validate_sections_xlsx(path: Path) -> int:
+    """Parse ``path``; return course count. Raise if zero courses."""
+    courses = list_offered_courses(path)
+    n = len(courses)
+    if n == 0:
+        raise SectionsValidationError(
+            f"{path} parsed to 0 offered courses — export is empty or Workday "
+            "layout/filters changed. Not overwriting the shared catalog."
+        )
+    return n
+
+
+# ── Workday navigation (fragile DOM — comments document assumptions) ─────────
+
+
+def _page_heading_lower(page: Any) -> str:
+    try:
+        title = (page.title() or "").lower()
+        heading = page.evaluate(
+            "() => (document.querySelector('h1, [role=\"heading\"]') || {})"
+            ".textContent || ''"
+        )
+        return f"{title} {str(heading).lower()}"
+    except Exception:  # noqa: BLE001
+        return (page.title() or "").lower()
+
+
+def on_find_course_sections_page(page: Any) -> bool:
+    blob = _page_heading_lower(page)
+    return any(h in blob for h in _SECTIONS_HEADINGS)
+
+
+def _try_global_search(page: Any, query: str) -> bool:
+    """Workday universal search → open *Find Course Sections* (search fallback)."""
+    box = None
+    for sel in _SEARCH_BOX_SELECTORS:
+        try:
+            page.wait_for_selector(sel, timeout=4_000, state="visible")
+            box = page.locator(sel).first
+            box.click()
+            break
+        except Exception:  # noqa: BLE001
+            box = None
+    if box is None:
+        return False
+
+    try:
+        box.fill(query)
+        page.wait_for_timeout(1_500)
+        for sel in _SEARCH_SUGGESTION_SELECTORS:
+            try:
+                page.locator(sel).first.click(timeout=3_000)
+                page.wait_for_load_state("domcontentloaded", timeout=30_000)
+                page.wait_for_timeout(wb.RENDER_WAIT_MS)
+                if on_find_course_sections_page(page):
+                    return True
+            except Exception:  # noqa: BLE001
+                continue
+        page.keyboard.press("Enter")
+        page.wait_for_load_state("domcontentloaded", timeout=30_000)
+        page.wait_for_timeout(wb.RENDER_WAIT_MS)
+        return on_find_course_sections_page(page)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _click_visible_text(page: Any, text: str, *, timeout: int = 3_000) -> bool:
+    try:
+        page.get_by_text(text, exact=False).first.click(timeout=timeout)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _select_filter_option(page: Any, label_keywords: tuple[str, ...], value: str) -> bool:
+    """Open a filter whose label matches ``label_keywords`` and pick ``value``.
+
+    Workday filter rows vary by tenant refresh — we try label text, combobox
+    roles, and common ``data-automation-id`` patterns. Failure is non-fatal
+    (caller may still get a partial export).
+    """
+    value_re = re.compile(re.escape(value), re.I)
+    # Strategy A: filter prompt button near a label keyword
+    for kw in label_keywords:
+        try:
+            row = page.locator(f'[data-automation-id*="filter" i]').filter(
+                has_text=re.compile(kw, re.I)
+            ).first
+            if row.count() > 0:
+                row.click(timeout=2_000)
+                page.wait_for_timeout(400)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            page.get_by_role("button", name=re.compile(kw, re.I)).first.click(timeout=2_000)
+            page.wait_for_timeout(400)
+        except Exception:  # noqa: BLE001
+            continue
+
+    # Strategy B: combobox / listbox option with the term/level text
+    for role in ("option", "menuitem", "treeitem"):
+        try:
+            page.get_by_role(role, name=value_re).first.click(timeout=3_000)
+            return True
+        except Exception:  # noqa: BLE001
+            continue
+
+    # Strategy C: plain text match in the open panel
+    if _click_visible_text(page, value):
+        page.wait_for_timeout(300)
+        return True
+
+    # Strategy D: type into an active search field inside the filter popup
+    try:
+        active = page.locator(
+            'input:focus, [data-automation-id*="search" i] input, '
+            '[role="combobox"] input'
+        ).first
+        active.fill(value, timeout=2_000)
+        page.wait_for_timeout(500)
+        page.keyboard.press("Enter")
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _run_search(page: Any) -> None:
+    for sel in _SEARCH_RUN_SELECTORS:
+        try:
+            page.click(sel, timeout=3_000)
+            page.wait_for_timeout(wb.RENDER_WAIT_MS)
+            return
+        except Exception:  # noqa: BLE001
+            continue
+
+
+def navigate_find_course_sections(
+    page: Any,
+    *,
+    term: str,
+    level: str,
+    task_url: str | None,
+) -> None:
+    """Drive ``page`` to filtered Find Course Sections results (pre-export).
+
+    Order: direct task URL (if set) → global search fallback → term/level
+    filters → Search. Raises ``RuntimeError`` when the report cannot be reached.
+    """
+    if task_url:
+        try:
+            page.goto(task_url, wait_until="domcontentloaded", timeout=wb.NAV_TIMEOUT_MS)
+            page.wait_for_timeout(wb.RENDER_WAIT_MS)
+        except Exception:  # noqa: BLE001
+            pass
+        if on_find_course_sections_page(page):
+            pass
+        else:
+            task_url = None  # stale task id — fall through to search
+
+    if not on_find_course_sections_page(page):
+        if not _try_global_search(page, _SEARCH_QUERY):
+            actual = ""
+            try:
+                actual = (page.title() or "").strip()
+            except Exception:  # noqa: BLE001
+                pass
+            raise RuntimeError(
+                "Could not open Workday 'Find Course Sections'. "
+                f"Currently on {actual!r}. Set "
+                f"{_SECTIONS_URL_ENV} to a direct task URL or fix search selectors."
+            )
+
+    _select_filter_option(page, _TERM_FILTER_LABELS, term)
+    _select_filter_option(page, _LEVEL_FILTER_LABELS, level)
+    _run_search(page)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Pull Find Course Sections xlsx from Workday (headed browser)."
+    )
+    p.add_argument(
+        "--term",
+        default=os.environ.get(_TERM_ENV) or default_term_name(),
+        help="Academic period / quarter filter text (default: upcoming quarter heuristic).",
+    )
+    p.add_argument(
+        "--level",
+        default=default_academic_level(),
+        help="Academic level filter (default: Undergraduate).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate only; do not write SCU_Find_Course_Sections.xlsx.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        from playwright.sync_api import TimeoutError as PWTimeout
+    except ImportError:
+        print(
+            "ERROR: playwright is not installed. Run: pip install -r project/requirements.txt "
+            "&& playwright install chromium",
+            file=sys.stderr,
+            flush=True,
+        )
+        return EXIT_USAGE
+
+    args = _parse_args(argv)
+    task_url = (os.environ.get(_SECTIONS_URL_ENV) or "").strip() or None
+
+    context = None
+    try:
+        context, page = wb.launch(PROFILE_DIR)
+        wb.wait_for_login(page)
+
+        def _navigate(pg: Any) -> None:
+            navigate_find_course_sections(
+                pg,
+                term=args.term.strip(),
+                level=args.level.strip(),
+                task_url=task_url,
+            )
+
+        data = wb.export_to_excel(page, _navigate)
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tf:
+            tmp = Path(tf.name)
+            tmp.write_bytes(data)
+        try:
+            n = validate_sections_xlsx(tmp)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+        if args.dry_run:
+            print(f"Dry run OK — validated {n} courses (catalog not written).", flush=True)
+        else:
+            atomic_write_xlsx(DEST_XLSX, data)
+            print(f"Wrote {DEST_XLSX} ({n} courses).", flush=True)
+
+        print(
+            "\nReminder: restart the API or POST /api/courses/refresh so cached "
+            "schedule indexes reload the new xlsx.\n",
+            flush=True,
+        )
+        return EXIT_OK
+
+    except SectionsValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr, flush=True)
+        return EXIT_VALIDATION
+    except TimeoutError as exc:
+        print(f"ERROR: login timed out — {exc}", file=sys.stderr, flush=True)
+        return EXIT_LOGIN
+    except RuntimeError as exc:
+        msg = str(exc).lower()
+        code = EXIT_NAVIGATION if "find course sections" in msg or "open workday" in msg else EXIT_EXPORT
+        print(f"ERROR: {exc}", file=sys.stderr, flush=True)
+        return code
+    except PWTimeout as exc:
+        print(f"ERROR: Workday timed out — {exc}", file=sys.stderr, flush=True)
+        return EXIT_NAVIGATION
+    except OSError as exc:
+        print(f"ERROR: failed to write catalog — {exc}", file=sys.stderr, flush=True)
+        return EXIT_WRITE
+    finally:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/project/course_planner/utils/scu_course_schedule_xlsx.py
+++ b/project/course_planner/utils/scu_course_schedule_xlsx.py
@@ -896,6 +896,17 @@ _LAB_PAIR_SUBJECTS = frozenset(
 )
 
 
+def clear_schedule_caches() -> None:
+    """Drop in-process schedule caches after ``SCU_Find_Course_Sections.xlsx`` is replaced.
+
+    ``list_offered_courses`` reads the xlsx on each call, but ``load_core_integrations_course_set``
+    and ``load_instructor_ratings`` are ``lru_cache``-d. Pair with
+    ``courses._cached_courses.cache_clear()`` in the API router.
+    """
+    load_core_integrations_course_set.cache_clear()
+    load_instructor_ratings.cache_clear()
+
+
 def list_offered_courses(path: Path | None = None) -> list[dict[str, Any]]:
     """Return every distinct course offered next term, shaped for the manual
     "+ Add course" picker AND for direct placement on the calendar.

--- a/project/tests/test_courses_refresh.py
+++ b/project/tests/test_courses_refresh.py
@@ -1,0 +1,21 @@
+"""POST /api/courses/refresh clears the catalog lru_cache."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routers import courses as courses_router
+
+
+def test_courses_refresh_returns_ok_and_count():
+    courses_router._cached_courses.cache_clear()
+    client = TestClient(app)
+    before = client.get("/api/courses").json()["count"]
+    refreshed = client.post("/api/courses/refresh")
+    assert refreshed.status_code == 200
+    body = refreshed.json()
+    assert body["ok"] is True
+    assert body["count"] == before
+    after = client.get("/api/courses").json()["count"]
+    assert after == before

--- a/project/tests/test_workday_browser_scripts.py
+++ b/project/tests/test_workday_browser_scripts.py
@@ -1,0 +1,283 @@
+"""Tests for scripts/_workday_browser.py (the headed Workday pull helper).
+
+A real Playwright browser can't run in CI, so the browser-driving paths are
+exercised against lightweight fakes. These pin the acceptance criteria:
+
+  * the module imports
+  * launch / wait_for_login / export_to_excel have the agreed signatures
+  * first run creates the profile directory (and uses a headed, downloads-on,
+    persistent context)
+  * export_to_excel runs the navigate callback and returns the downloaded bytes
+  * wait_for_login blocks-then-returns on success and raises on timeout
+  * the module never handles SCU credentials
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")  # skip module if Playwright absent
+
+from scripts import _workday_browser as wb  # noqa: E402
+
+
+# ── Signatures (the two pull scripts depend on these) ────────────────────────
+
+
+def test_public_api_exported():
+    assert wb.__all__ == ["launch", "wait_for_login", "export_to_excel"]
+    for name in wb.__all__:
+        assert callable(getattr(wb, name))
+
+
+def test_launch_signature():
+    params = inspect.signature(wb.launch).parameters
+    assert list(params) == ["profile_dir"]
+
+
+def test_wait_for_login_signature():
+    sig = inspect.signature(wb.wait_for_login)
+    assert list(sig.parameters) == ["page", "timeout_s"]
+    timeout_s = sig.parameters["timeout_s"]
+    assert timeout_s.kind is inspect.Parameter.KEYWORD_ONLY
+    assert timeout_s.default == 300
+
+
+def test_export_to_excel_signature():
+    assert list(inspect.signature(wb.export_to_excel).parameters) == ["page", "navigate"]
+
+
+# ── launch: profile dir + persistent-context options ─────────────────────────
+
+
+class _FakeLaunchPage:
+    def __init__(self, url=wb.WORKDAY_HOME):
+        self.url = url
+        self.goto_calls: list[str] = []
+
+    def goto(self, url, **_kw):
+        self.goto_calls.append(url)
+
+
+class _FakeContext:
+    def __init__(self, launch_kwargs):
+        self.launch_kwargs = launch_kwargs
+        self.pages = [_FakeLaunchPage()]
+
+
+class _FakeChromium:
+    def launch_persistent_context(self, **kwargs):
+        return _FakeContext(kwargs)
+
+
+class _FakePlaywright:
+    def __init__(self):
+        self.chromium = _FakeChromium()
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+
+def _patch_playwright(monkeypatch):
+    pw = _FakePlaywright()
+    monkeypatch.setattr(wb, "sync_playwright", lambda: SimpleNamespace(start=lambda: pw))
+    return pw
+
+
+def test_launch_creates_profile_dir_first_run(tmp_path, monkeypatch):
+    _patch_playwright(monkeypatch)
+    profile = tmp_path / "nested" / ".workday_profile"
+    assert not profile.exists()
+
+    context, page = wb.launch(profile)
+
+    assert profile.is_dir()  # created on first run
+    assert context.launch_kwargs["user_data_dir"] == str(profile)
+    assert page.goto_calls == [wb.WORKDAY_HOME]
+
+
+def test_launch_is_headed_with_downloads(tmp_path, monkeypatch):
+    _patch_playwright(monkeypatch)
+    context, _page = wb.launch(tmp_path / "profile")
+    assert context.launch_kwargs["headless"] is False  # never headless
+    assert context.launch_kwargs["accept_downloads"] is True
+
+
+def test_launch_keeps_driver_reference(tmp_path, monkeypatch):
+    """The Playwright driver must stay referenced so it isn't GC'd mid-session."""
+    pw = _patch_playwright(monkeypatch)
+    context, _page = wb.launch(tmp_path / "profile")
+    assert context._playwright is pw
+
+
+# ── wait_for_login ───────────────────────────────────────────────────────────
+
+
+def _fake_page(url="", pages=None):
+    page = SimpleNamespace()
+    page.url = url
+    page.context = SimpleNamespace(pages=pages if pages is not None else [page])
+    return page
+
+
+def test_wait_for_login_returns_when_logged_in(monkeypatch, capsys):
+    monkeypatch.setattr(wb.time, "sleep", lambda _s: pytest.fail("should not sleep"))
+    page = _fake_page(url="https://www.myworkday.com/scu/d/home.htmld")
+    assert wb.wait_for_login(page) is None
+    assert "log in" in capsys.readouterr().out.lower()
+
+
+def test_wait_for_login_times_out(monkeypatch):
+    monkeypatch.setattr(wb.time, "sleep", lambda _s: None)
+    stuck = _fake_page(url="https://login.scu.edu/sso")
+    with pytest.raises(TimeoutError):
+        wb.wait_for_login(stuck, timeout_s=0)
+
+
+def test_wait_for_login_detects_workday_in_secondary_tab(monkeypatch):
+    monkeypatch.setattr(wb.time, "sleep", lambda _s: pytest.fail("should not sleep"))
+    sso = _fake_page(url="https://login.scu.edu/sso")
+    workday = _fake_page(url="https://www.myworkday.com/scu/d/home.htmld")
+    sso.context.pages = [sso, workday]
+    assert wb.wait_for_login(sso) is None
+
+
+# ── export_to_excel ──────────────────────────────────────────────────────────
+
+
+class _FakeDownload:
+    def __init__(self, path):
+        self._path = path
+
+    def path(self):
+        return self._path
+
+
+class _DownloadCtx:
+    def __init__(self, download):
+        self._download = download
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    @property
+    def value(self):
+        return self._download
+
+
+class _FakeExportPage:
+    """Fake page where the first direct selector yields a download."""
+
+    def __init__(self, download_path):
+        self.url = "https://www.myworkday.com/scu/d/task/X.htmld"
+        self._download_path = download_path
+
+    def wait_for_load_state(self, *_a, **_k):
+        pass
+
+    def wait_for_timeout(self, *_a, **_k):
+        pass
+
+    def wait_for_selector(self, *_a, **_k):
+        return None  # selector "found"
+
+    def expect_download(self, *_a, **_k):
+        return _DownloadCtx(_FakeDownload(self._download_path))
+
+    def click(self, *_a, **_k):
+        pass
+
+
+def test_export_to_excel_runs_navigate_and_returns_bytes(tmp_path):
+    xlsx = tmp_path / "academic_progress.xlsx"
+    xlsx.write_bytes(b"PK\x03\x04 fake xlsx bytes")
+
+    page = _FakeExportPage(str(xlsx))
+    visited: list[object] = []
+
+    data = wb.export_to_excel(page, lambda pg: visited.append(pg))
+
+    assert data == b"PK\x03\x04 fake xlsx bytes"
+    assert visited == [page]  # navigate callback ran with the page
+
+
+class _NoExportPage:
+    """Fake page where no export control is ever found."""
+
+    def __init__(self):
+        self.url = "https://www.myworkday.com/scu/d/task/X.htmld"
+        self.screenshot_calls = 0
+
+    def wait_for_load_state(self, *_a, **_k):
+        pass
+
+    def wait_for_timeout(self, *_a, **_k):
+        pass
+
+    def wait_for_selector(self, *_a, **_k):
+        raise wb.PWTimeout("not found")
+
+    def click(self, *_a, **_k):
+        raise wb.PWTimeout("not found")
+
+    def keyboard_press(self, *_a, **_k):
+        pass
+
+    @property
+    def keyboard(self):
+        return SimpleNamespace(press=lambda *_a, **_k: None)
+
+    def evaluate(self, *_a, **_k):
+        return []
+
+    def screenshot(self, *_a, **_k):
+        self.screenshot_calls += 1
+
+
+def test_export_to_excel_raises_when_no_control_found():
+    page = _NoExportPage()
+    with pytest.raises(RuntimeError, match="Export to Excel"):
+        wb.export_to_excel(page, lambda _pg: None)
+    assert page.screenshot_calls == 1  # debug screenshot attempted
+
+
+# ── Safety: never handles credentials ────────────────────────────────────────
+
+
+def test_module_never_handles_credentials():
+    """Acceptance constraint: zero credential handling anywhere in the module.
+
+    Checked at the AST level (not prose) so the docstring's "never stores
+    passwords" copy doesn't trip it. The module must never prompt for secrets
+    (``input`` / ``getpass``) nor type into form fields (``.fill`` — the human
+    types their own credentials).
+    """
+    tree = ast.parse(Path(wb.__file__).read_text(encoding="utf-8"))
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert "getpass" not in imported
+
+    called: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            if isinstance(fn, ast.Name):
+                called.add(fn.id)
+            elif isinstance(fn, ast.Attribute):
+                called.add(fn.attr)
+    for forbidden in ("input", "getpass", "fill"):
+        assert forbidden not in called, f"credential-handling call {forbidden!r} present"

--- a/project/tests/test_workday_pull_progress.py
+++ b/project/tests/test_workday_pull_progress.py
@@ -1,0 +1,152 @@
+"""Tests for scripts/workday_pull_progress.py (no real Playwright in CI)."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from openpyxl import Workbook
+
+from scripts import workday_pull_progress as wpp
+
+
+def _empty_progress_xlsx() -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Requirement", "Status", "Remaining", "Registration", "Period", "Units", "Grade"])
+    buf = BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _minimal_progress_xlsx() -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["Requirement", "Status", "Remaining", "Registration", "Period", "Units", "Grade"])
+    ws.append(
+        [
+            "Core Curriculum",
+            "Satisfied",
+            None,
+            "COEN 10 - Intro",
+            "Fall 2024",
+            4,
+            None,
+        ],
+    )
+    buf = BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+
+def test_validate_progress_export_aborts_on_empty_parse():
+    with pytest.raises(wpp.ProgressValidationError, match="ZERO rows"):
+        wpp.validate_progress_export(_empty_progress_xlsx())
+
+
+def test_validate_progress_export_accepts_nonempty():
+    data = wpp.validate_progress_export(_minimal_progress_xlsx())
+    assert data["detail_rows"]
+
+
+# ── Page heuristics (mocked page) ───────────────────────────────────────────
+
+
+def _page_with_title(title: str, *, heading: str = ""):
+    return SimpleNamespace(
+        title=lambda: title,
+        evaluate=lambda _js: heading,
+        url="https://www.myworkday.com/scu/d/task/2998$44123.htmld",
+        wait_for_load_state=lambda *_a, **_k: None,
+        wait_for_timeout=lambda *_a, **_k: None,
+    )
+
+
+def test_on_academic_progress_page_title_match():
+    page = _page_with_title("View My Academic Progress")
+    assert wpp._on_academic_progress_page(page) is True
+
+
+def test_on_academic_progress_page_heading_match():
+    page = _page_with_title("Workday", heading="My Academic Progress")
+    assert wpp._on_academic_progress_page(page) is True
+
+
+def test_on_academic_progress_page_rejects_unrelated():
+    page = _page_with_title("Find Course Sections", heading="Course Catalog")
+    assert wpp._on_academic_progress_page(page) is False
+
+
+def test_ensure_on_task_skips_goto_when_already_there(monkeypatch):
+    page = _page_with_title("View My Academic Progress")
+    page.goto = pytest.fail  # type: ignore[attr-defined]
+    wpp._ensure_on_task(page)  # should return without navigating
+
+
+def test_ensure_on_task_raises_when_navigation_fails(monkeypatch):
+    page = _page_with_title("Wrong Report", heading="Active Holds")
+    page.goto = lambda *_a, **_k: None  # type: ignore[attr-defined]
+    page.wait_for_load_state = lambda *_a, **_k: None  # type: ignore[attr-defined]
+    page.wait_for_timeout = lambda *_a, **_k: None  # type: ignore[attr-defined]
+    monkeypatch.setattr(wpp, "_try_search_for_report", lambda _p: False)
+    with pytest.raises(RuntimeError, match="View My Academic Progress"):
+        wpp._ensure_on_task(page, task_url=wpp.TASK_URL)
+
+
+# ── CLI / upload (mocked) ─────────────────────────────────────────────────────
+
+
+def test_main_save_mode_writes_file(tmp_path, monkeypatch):
+    fake_bytes = _minimal_progress_xlsx()
+
+    def _fake_pull():
+        return fake_bytes
+
+    monkeypatch.setattr(wpp, "launch", lambda _p: (_NoCloseContext(), object()))
+    monkeypatch.setattr(wpp, "wait_for_login", lambda _page: None)
+    monkeypatch.setattr(wpp, "export_to_excel", lambda _page, _nav: _fake_pull())
+
+    out = tmp_path / "progress.xlsx"
+    assert wpp.main(["--save", str(out)]) == 0
+    assert out.read_bytes() == fake_bytes
+
+
+def test_main_upload_failure_returns_1(monkeypatch):
+    monkeypatch.setattr(wpp, "launch", lambda _p: (_NoCloseContext(), object()))
+    monkeypatch.setattr(wpp, "wait_for_login", lambda _page: None)
+    monkeypatch.setattr(
+        wpp,
+        "export_to_excel",
+        lambda _page, _nav: _minimal_progress_xlsx(),
+    )
+
+    def _boom(**_kw):
+        raise ConnectionError("API down")
+
+    monkeypatch.setattr(wpp, "_post_transcript", _boom)
+    assert wpp.main(["--user-id", "u-test"]) == 1
+
+
+def test_main_login_timeout_returns_2(monkeypatch):
+    monkeypatch.setattr(wpp, "launch", lambda _p: (_NoCloseContext(), object()))
+
+    def _timeout(_page, **_kw):
+        raise TimeoutError("login timed out")
+
+    monkeypatch.setattr(wpp, "wait_for_login", _timeout)
+    assert wpp.main(["--save", "/tmp/x.xlsx"]) == 2
+
+
+def test_parser_save_takes_precedence_over_user_id():
+    args = wpp._build_parser().parse_args(["--user-id", "alice", "--save", "out.xlsx"])
+    assert args.save is not None
+    assert args.user_id == "alice"
+
+
+class _NoCloseContext:
+    def close(self):
+        pass

--- a/project/tests/test_workday_pull_sections.py
+++ b/project/tests/test_workday_pull_sections.py
@@ -1,0 +1,59 @@
+"""Tests for scripts/workday_pull_sections.py (no Playwright in CI)."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts import workday_pull_sections as wps
+
+
+def test_atomic_write_xlsx_replaces_dest(tmp_path: Path) -> None:
+    dest = tmp_path / "SCU_Find_Course_Sections.xlsx"
+    dest.write_bytes(b"old")
+    wps.atomic_write_xlsx(dest, b"PK\x03\x04 new")
+    assert dest.read_bytes() == b"PK\x03\x04 new"
+    assert not dest.with_suffix(".xlsx.tmp").exists()
+
+
+def test_atomic_write_cleans_tmp_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dest = tmp_path / "out.xlsx"
+    monkeypatch.setattr(wps.os, "replace", MagicMock(side_effect=OSError("disk full")))
+    with pytest.raises(OSError, match="disk full"):
+        wps.atomic_write_xlsx(dest, b"x")
+    assert not dest.with_suffix(".xlsx.tmp").exists()
+
+
+def test_validate_sections_xlsx_returns_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = [{"course": "CSEN 20", "title": "Intro"}]
+    monkeypatch.setattr(wps, "list_offered_courses", lambda _p: fake)
+    n = wps.validate_sections_xlsx(tmp_path / "any.xlsx")
+    assert n == 1
+
+
+def test_validate_sections_xlsx_rejects_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(wps, "list_offered_courses", lambda _p: [])
+    with pytest.raises(wps.SectionsValidationError, match="0 offered courses"):
+        wps.validate_sections_xlsx(tmp_path / "empty.xlsx")
+
+
+def test_default_term_name_spring_in_january() -> None:
+    assert wps.default_term_name(date(2026, 2, 1)) == "Spring 2026"
+
+
+def test_default_term_name_fall_in_may() -> None:
+    assert wps.default_term_name(date(2026, 5, 24)) == "Fall 2026"
+
+
+def test_on_find_course_sections_page_detects_heading() -> None:
+    page = MagicMock()
+    page.title.return_value = "Find Course Sections"
+    page.evaluate.return_value = ""
+    assert wps.on_find_course_sections_page(page) is True


### PR DESCRIPTION
## Summary
Branch-prototype implementation of **Workday auto-pull** (the `.gitignore` + docs groundwork landed in #39). Two **headed** Playwright scripts let a human complete SSO + Duo in a real browser, then automate **Export to Excel** — **zero stored credentials**; the only persisted state is the gitignored `.workday_profile/`.

- `scripts/_workday_browser.py` — persistent-context launch + `wait_for_login` + `export_to_excel` helper (never handles credentials; enforced by `test_module_never_handles_credentials`).
- `scripts/workday_pull_progress.py` — per-student *View My Academic Progress* pull (`--user-id` POSTs to `/api/upload/transcript`; `--save` writes the `.xlsx`).
- `scripts/workday_pull_sections.py` — admin *Find Course Sections* pull; atomically overwrites the shared `SCU_Find_Course_Sections.xlsx`.
- `scripts/validate_workday_e2e.py` — e2e / safety validation harness.
- `api/routers/courses.py` + `utils/scu_course_schedule_xlsx.py` — add `POST /api/courses/refresh` + `clear_schedule_caches()` so a freshly pulled catalog is served **without restarting the API**.

## Prototype boundary
Trigger is **CLI** (a web page can't launch a local browser); productionizing as a browser extension is future work. See `project/course_planner/scripts/README.md`.

## Test plan
- [ ] CI (`test`) green — incl. `test_courses_refresh`, `test_workday_browser_scripts`, `test_workday_pull_progress`, `test_workday_pull_sections`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)