### PR TITLE
Integrate: workday nav optimization + in-app catalog sync

### DIFF
--- a/project/api/middleware/rate_limit.py
+++ b/project/api/middleware/rate_limit.py
@@ -83,6 +83,7 @@ DEFAULT_LIMITS: Dict[str, RouteLimits] = {
     "four_year_plan": RouteLimits(per_minute_ip=5, per_minute_user=10, max_concurrent_per_user=1),
     "slot_suggest": RouteLimits(per_minute_ip=60, per_minute_user=120, max_concurrent_per_user=4),
     "workday_sync": RouteLimits(per_minute_ip=3, per_minute_user=6, max_concurrent_per_user=1),
+    "workday_sync_sections": RouteLimits(per_minute_ip=3, per_minute_user=6, max_concurrent_per_user=1),
 }
 
 

--- a/project/api/routers/workday.py
+++ b/project/api/routers/workday.py
@@ -1,13 +1,20 @@
 """
 Workday headed-browser pull (local dev).
 
-POST /api/workday/sync                  → {job_id}
-GET  /api/workday/status/{job_id}       → {status, label, missing_details?, error?}
+POST /api/workday/sync                  → {job_id}   (per-user Academic Progress)
+POST /api/workday/sync-sections         → {job_id}   (shared Find Course Sections)
+GET  /api/workday/status/{job_id}       → {status, label, missing_details?, count?, error?}
 GET  /api/workday/available             → {available: bool}
 
 The student completes SSO + Duo in a visible Chromium window on the machine
 where the API runs. No SCU passwords are stored — only a gitignored browser
 profile under ``course_planner/.workday_profile/``.
+
+``/sync`` pulls *View My Academic Progress* into the requester's own memory.
+``/sync-sections`` pulls the *Find Course Sections* catalog — course
+availability is identical for every student, so it overwrites the **shared**
+``SCU_Find_Course_Sections.xlsx`` and refreshes everyone's catalog. Any
+authenticated user may trigger it (the frontend asks for confirmation first).
 
 Disabled on hosts without Playwright or when ``SCU_WORKDAY_PULL_ENABLED=0``.
 """
@@ -41,7 +48,23 @@ _STATUS_LABELS: dict[str, str] = {
     "error": "Sync failed.",
 }
 
+_SECTIONS_STATUS_LABELS: dict[str, str] = {
+    "pending": "Starting browser…",
+    "browser_open": "Browser open — complete SCU login and Duo in that window",
+    "logged_in": "Login detected — opening Find Course Sections…",
+    "navigating": "Opening Find Course Sections…",
+    "downloading": "Applying term/level filters and exporting…",
+    "exporting": "Click the Excel icon on the report (or wait — retrying every few seconds)…",
+    "validating": "Validating the course catalog…",
+    "writing": "Saving the shared catalog…",
+    "done": "Done — course catalog updated!",
+    "error": "Catalog sync failed.",
+}
+
 _GENERIC_ERROR = "Sync failed. Try uploading manually with the paperclip button."
+_GENERIC_SECTIONS_ERROR = (
+    "Catalog sync failed. Try again, or run scripts/workday_pull_sections.py locally."
+)
 
 
 def _playwright_importable() -> bool:
@@ -80,6 +103,26 @@ def _scrub_error(exc: BaseException) -> str:
     if "Could not reach" in msg or "Find Course Sections" in msg:
         return "Could not open Academic Progress in Workday. Try again or upload manually."
     return _GENERIC_ERROR
+
+
+def _scrub_sections_error(exc: BaseException) -> str:
+    """Like ``_scrub_error`` but with catalog-appropriate wording (no per-user upload)."""
+    name = type(exc).__name__
+    if name in {"PWTimeout", "PlaywrightTimeoutError", "TimeoutError"}:
+        if isinstance(exc, TimeoutError):
+            return "Login timed out. Complete SSO and Duo in the browser window, then try again."
+        return "Workday took too long to respond."
+    if isinstance(exc, ModuleNotFoundError) or name in {"ImportError", "ModuleNotFoundError"}:
+        return "Workday sync is not enabled on this server."
+    msg = str(exc).strip()
+    if "0 offered courses" in msg or "parsed to 0" in msg:
+        return (
+            "The export contained no courses — Workday's term/level filters or layout "
+            "may have changed. The shared catalog was left unchanged."
+        )
+    if "Find Course Sections" in msg or "open workday" in msg.lower():
+        return "Could not open Find Course Sections in Workday. Try again later."
+    return _GENERIC_SECTIONS_ERROR
 
 
 _jobs: dict[str, dict[str, Any]] = {}
@@ -131,6 +174,43 @@ def _run_pull(job_id: str, user_id: str) -> None:
         )
 
 
+def _invalidate_course_catalog_cache() -> None:
+    """Drop catalog caches so ``GET /api/courses`` serves the new xlsx without a restart."""
+    try:
+        from routers.courses import refresh_courses
+
+        refresh_courses()
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to refresh course catalog cache after sections pull", exc_info=True)
+
+
+def _run_sections_pull(job_id: str) -> None:
+    def cb(status: str) -> None:
+        _set_job(job_id, status=status, label=_SECTIONS_STATUS_LABELS.get(status, status))
+
+    try:
+        from scripts.workday_pull_sections import pull_course_sections
+
+        result = pull_course_sections(progress_cb=cb)
+        _invalidate_course_catalog_cache()
+        _set_job(
+            job_id,
+            status="done",
+            label=_SECTIONS_STATUS_LABELS["done"],
+            count=int(result.get("count") or 0),
+            term=str(result.get("term") or ""),
+            level=str(result.get("level") or ""),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Workday sections pull failed for job_id=%s", job_id)
+        _set_job(
+            job_id,
+            status="error",
+            label=_SECTIONS_STATUS_LABELS["error"],
+            error=_scrub_sections_error(exc),
+        )
+
+
 class SyncRequest(BaseModel):
     user_id: str = ""
 
@@ -156,6 +236,31 @@ def start_sync(body: SyncRequest) -> dict[str, str]:
         user_id=user_id,
     )
     threading.Thread(target=_run_pull, args=(job_id, user_id), daemon=True).start()
+    return {"job_id": job_id}
+
+
+@router.post("/sync-sections", dependencies=[Depends(limit("workday_sync_sections"))])
+def start_sections_sync(body: SyncRequest) -> dict[str, str]:
+    """Start a headed pull of the shared Find Course Sections catalog.
+
+    The result overwrites the shared catalog for *all* users, so the frontend
+    confirms before calling this. Any authenticated user may trigger it; the job
+    is tracked under the requester's id so only they poll its status.
+    """
+    if not workday_pull_enabled():
+        raise HTTPException(
+            status_code=503,
+            detail="Workday sync is not available on this server.",
+        )
+    user_id = _require_user(body.user_id)
+    job_id = str(uuid.uuid4())
+    _set_job(
+        job_id,
+        status="pending",
+        label=_SECTIONS_STATUS_LABELS["pending"],
+        user_id=user_id,
+    )
+    threading.Thread(target=_run_sections_pull, args=(job_id,), daemon=True).start()
     return {"job_id": job_id}
 
 

--- a/project/course_planner/scripts/_workday_browser.py
+++ b/project/course_planner/scripts/_workday_browser.py
@@ -223,17 +223,32 @@ def _active_workday_page(initial: Page) -> Page | None:
     return initial if _on_workday(initial) else None
 
 
-def _wait_for_render(page: Page) -> None:
+def _wait_for_render(page: Page, ready: Callable[[], bool] | None = None) -> None:
     """Wait for Workday content to paint.
 
     ``networkidle`` never fires on Workday (the SPA polls forever), so we wait
-    for ``domcontentloaded`` plus a short fixed pause instead.
+    for ``domcontentloaded`` then, with ``ready`` given, poll until the next view
+    is up (capped at ``RENDER_WAIT_MS`` of summed poll steps) instead of always
+    sleeping the full pause. Summing steps (not wall clock) keeps the cap honest
+    when ``page.wait_for_timeout`` is a test no-op.
     """
     try:
         page.wait_for_load_state("domcontentloaded", timeout=30_000)
     except PWTimeout:
         pass
-    page.wait_for_timeout(RENDER_WAIT_MS)
+    if ready is None:
+        page.wait_for_timeout(RENDER_WAIT_MS)
+        return
+    waited = 0
+    step = 150
+    while waited < RENDER_WAIT_MS:
+        try:
+            if ready():
+                return
+        except Exception:  # noqa: BLE001
+            pass
+        page.wait_for_timeout(step)
+        waited += step
 
 
 # ── Public: launch ───────────────────────────────────────────────────────────
@@ -574,7 +589,10 @@ def export_to_excel(
     write garbage.
     """
     navigate(page)
-    _wait_for_render(page)
+    _wait_for_render(
+        page,
+        lambda: export_controls_visible(page) or _export_document_modal_visible(page),
+    )
 
     strategies = (
         _download_via_export_document_modal,

--- a/project/course_planner/scripts/workday_pull_progress.py
+++ b/project/course_planner/scripts/workday_pull_progress.py
@@ -122,12 +122,53 @@ def _print_xlsx_preview(xlsx_bytes: bytes, *, max_rows: int = 8) -> None:
 # ── Navigation (recovered from utils/workday_scraper.py @ c095321^) ───────────
 
 
-def _wait_for_workday_content(page: Page) -> None:
+def _wait_for_workday_content(
+    page: Page, ready: Callable[[], bool] | None = None
+) -> None:
+    """Let the Workday SPA paint after a navigation.
+
+    With ``ready`` given, return as soon as it reports the next view is up
+    (polled), capped at ``RENDER_WAIT_MS``; otherwise fall back to the fixed
+    pause that older runs relied on. The cap is counted as summed poll steps
+    (not wall clock) so it still terminates promptly when ``wait_for_timeout``
+    is a test no-op.
+    """
     try:
         page.wait_for_load_state("domcontentloaded", timeout=30_000)
     except PWTimeout:
         pass
-    page.wait_for_timeout(RENDER_WAIT_MS)
+    if ready is None:
+        page.wait_for_timeout(RENDER_WAIT_MS)
+        return
+    waited = 0
+    step = 150
+    while waited < RENDER_WAIT_MS:
+        try:
+            if ready():
+                return
+        except Exception:  # noqa: BLE001
+            pass
+        page.wait_for_timeout(step)
+        waited += step
+
+
+def _any_visible(page: Page, *texts: str) -> Callable[[], bool]:
+    """Build a lightweight readiness check: any of ``texts`` currently visible.
+
+    Uses ``is_visible()`` with no timeout (an instant DOM check), so it is cheap
+    to poll and never adds its own waiting.
+    """
+
+    def _check() -> bool:
+        for t in texts:
+            try:
+                if page.get_by_text(t, exact=False).first.is_visible():
+                    return True
+            except Exception:  # noqa: BLE001
+                continue
+        return False
+
+    return _check
 
 
 def _student_selection_modal_visible(page: Page) -> bool:
@@ -171,7 +212,7 @@ def _dismiss_student_selection_modal(page: Page) -> bool:
         ):
             try:
                 target.click(timeout=5_000, force=True)
-                _wait_for_workday_content(page)
+                _wait_for_workday_content(page, lambda: _on_academic_progress_page(page))
                 page.wait_for_timeout(1_000)
                 if not _student_selection_modal_visible(page):
                     return True
@@ -223,8 +264,19 @@ def _finalize_report_page(page: Page) -> bool:
     return _on_academic_progress_page(page)
 
 
-def _click_labels(page: Page, labels: tuple[str, ...], *, role: str | None = None) -> bool:
-    """Click the first visible control matching any of ``labels``."""
+def _click_labels(
+    page: Page,
+    labels: tuple[str, ...],
+    *,
+    role: str | None = None,
+    ready: Callable[[], bool] | None = None,
+) -> bool:
+    """Click the first visible control matching any of ``labels``.
+
+    After a successful click, wait for the next view via ``ready`` (the element
+    the *next* step needs) instead of a blanket fixed pause — the win that turns
+    the ~4s-per-hop menu walk into "continue the moment it's painted".
+    """
     for label in labels:
         candidates: list[Any] = []
         if role:
@@ -245,7 +297,7 @@ def _click_labels(page: Page, labels: tuple[str, ...], *, role: str | None = Non
                 target.wait_for(state="visible", timeout=3_000)
                 target.click(timeout=5_000)
                 page.wait_for_timeout(400)
-                _wait_for_workday_content(page)
+                _wait_for_workday_content(page, ready)
                 return True
             except Exception:  # noqa: BLE001
                 continue
@@ -254,9 +306,13 @@ def _click_labels(page: Page, labels: tuple[str, ...], *, role: str | None = Non
 
 def _click_academic_progress_link(page: Page) -> bool:
     """Click *View My Academic Progress* when its menu group is already open."""
-    clicked = _click_labels(page, ("View My Academic Progress",), role="link") or _click_labels(
-        page, ("View My Academic Progress",)
-    )
+
+    def _report_or_modal() -> bool:
+        return _on_academic_progress_page(page) or _student_selection_modal_visible(page)
+
+    clicked = _click_labels(
+        page, ("View My Academic Progress",), role="link", ready=_report_or_modal
+    ) or _click_labels(page, ("View My Academic Progress",), ready=_report_or_modal)
     if not clicked:
         return False
     return _finalize_report_page(page)
@@ -269,15 +325,23 @@ def _try_home_academics_app(page: Page) -> bool:
         "View My Academic Progress…",
         flush=True,
     )
-    _wait_for_workday_content(page)
+    _wait_for_workday_content(page, _any_visible(page, "Academics", "SCU Academics"))
 
-    if not _click_labels(page, ("Academics", "SCU Academics"), role="link"):
-        if not _click_labels(page, ("Academics",)):
+    after_academics = _any_visible(page, "Academic Advising", "View More", "View All Apps")
+    if not _click_labels(
+        page, ("Academics", "SCU Academics"), role="link", ready=after_academics
+    ):
+        if not _click_labels(page, ("Academics",), ready=after_academics):
             return False
 
-    _click_labels(page, ("View More", "View All Apps", "View All Apps >", "View All"))
-    if not _click_labels(page, ("Academic Advising",)):
-        _click_labels(page, ("Academic Advising",), role="button")
+    _click_labels(
+        page,
+        ("View More", "View All Apps", "View All Apps >", "View All"),
+        ready=_any_visible(page, "Academic Advising"),
+    )
+    advising_ready = _any_visible(page, "View My Academic Progress")
+    if not _click_labels(page, ("Academic Advising",), ready=advising_ready):
+        _click_labels(page, ("Academic Advising",), role="button", ready=advising_ready)
 
     return _click_academic_progress_link(page)
 
@@ -285,8 +349,12 @@ def _try_home_academics_app(page: Page) -> bool:
 def _try_sidebar_menu(page: Page) -> bool:
     """Legacy/alternate layout: Academic Advising group already visible in a side nav."""
     print("Trying sidebar: Academic Advising → View My Academic Progress…", flush=True)
-    _wait_for_workday_content(page)
-    _click_labels(page, ("Academic Advising",))
+    _wait_for_workday_content(
+        page, _any_visible(page, "Academic Advising", "View My Academic Progress")
+    )
+    _click_labels(
+        page, ("Academic Advising",), ready=_any_visible(page, "View My Academic Progress")
+    )
     return _click_academic_progress_link(page)
 
 
@@ -311,6 +379,9 @@ def _try_search_for_report(page: Page) -> bool:
     if box is None:
         return False
 
+    def _report_ready() -> bool:
+        return _on_academic_progress_page(page) or _student_selection_modal_visible(page)
+
     try:
         box.fill(_SEARCH_QUERY)
         page.wait_for_timeout(1_500)
@@ -323,12 +394,12 @@ def _try_search_for_report(page: Page) -> bool:
         for sel in suggestion_selectors:
             try:
                 page.locator(sel).first.click(timeout=3_000)
-                _wait_for_workday_content(page)
+                _wait_for_workday_content(page, _report_ready)
                 if _on_academic_progress_page(page):
                     return True
             except Exception:  # noqa: BLE001
                 continue
-        _wait_for_workday_content(page)
+        _wait_for_workday_content(page, _report_ready)
         return _on_academic_progress_page(page)
     except Exception:  # noqa: BLE001
         return False
@@ -337,7 +408,13 @@ def _try_search_for_report(page: Page) -> bool:
 def _ensure_on_task(page: Page, task_url: str = TASK_URL) -> None:
     """Navigate to View My Academic Progress (Academics menu first — matches successful runs)."""
     print("Navigating to View My Academic Progress…", flush=True)
-    _wait_for_workday_content(page)
+
+    def _home_or_report() -> bool:
+        if _on_academic_progress_page(page) or _student_selection_modal_visible(page):
+            return True
+        return _any_visible(page, "Academics", "SCU Academics")()
+
+    _wait_for_workday_content(page, _home_or_report)
     if _finalize_report_page(page):
         print("Already on the Academic Progress report.", flush=True)
         return
@@ -351,9 +428,13 @@ def _ensure_on_task(page: Page, task_url: str = TASK_URL) -> None:
         return
 
     print("Opening task URL…", flush=True)
+
+    def _report_ready() -> bool:
+        return _on_academic_progress_page(page) or _student_selection_modal_visible(page)
+
     try:
         page.goto(task_url, timeout=NAV_TIMEOUT_MS, wait_until="domcontentloaded")
-        _wait_for_workday_content(page)
+        _wait_for_workday_content(page, _report_ready)
     except Exception:  # noqa: BLE001
         pass
     if _finalize_report_page(page):

--- a/project/course_planner/scripts/workday_pull_sections.py
+++ b/project/course_planner/scripts/workday_pull_sections.py
@@ -28,6 +28,7 @@ import os
 import re
 import sys
 import tempfile
+from collections.abc import Callable
 from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -67,7 +68,10 @@ if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
 from scripts import _workday_browser as wb  # noqa: E402
-from utils.scu_course_schedule_xlsx import list_offered_courses  # noqa: E402
+from utils.scu_course_schedule_xlsx import (  # noqa: E402
+    clear_schedule_caches,
+    list_offered_courses,
+)
 
 # ── Paths & exit codes (cron-friendly) ───────────────────────────────────────
 
@@ -344,6 +348,110 @@ def navigate_find_course_sections(
     _run_search(page)
 
 
+# ── Reusable pull (CLI + API share this) ─────────────────────────────────────
+
+
+def _export_sections_bytes(
+    *,
+    term: str,
+    level: str,
+    task_url: str | None,
+    profile_dir: Path,
+    progress_cb: Callable[[str], None] | None = None,
+) -> bytes:
+    """Headed login + navigate Find Course Sections + Export to Excel → raw bytes.
+
+    Opens the browser, blocks on human SSO + Duo, drives the report, and captures
+    Workday's native export. Does **not** validate or write — callers decide.
+    ``progress_cb`` receives coarse status codes (``navigating``/``exporting``…)
+    plus the ``browser_open``/``logged_in`` codes emitted by ``wait_for_login``.
+    """
+
+    def _cb(status: str) -> None:
+        if progress_cb is not None:
+            progress_cb(status)
+
+    context = None
+    try:
+        context, page = wb.launch(profile_dir)
+        page = wb.wait_for_login(page, progress_cb=progress_cb)
+        print("Exporting Find Course Sections to Excel…", flush=True)
+
+        def _navigate(pg: Any) -> None:
+            _cb("navigating")
+            navigate_find_course_sections(pg, term=term, level=level, task_url=task_url)
+
+        _cb("downloading")
+
+        def _export_poll() -> None:
+            _cb("exporting")
+
+        return wb.export_to_excel(page, _navigate, on_poll=_export_poll)
+    finally:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def pull_course_sections(
+    *,
+    term: str | None = None,
+    level: str | None = None,
+    task_url: str | None = None,
+    profile_dir: Path | None = None,
+    progress_cb: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Pull the shared *Find Course Sections* catalog and overwrite the xlsx.
+
+    The course-availability analogue of ``pull_academic_progress``: where that
+    writes per-user memory, this overwrites the **shared**
+    ``SCU_Find_Course_Sections.xlsx`` (course availability is the same for every
+    student) and drops in-process schedule caches so the next read reloads it.
+
+    ``term`` / ``level`` / ``task_url`` fall back to the same env vars and
+    heuristics as the CLI. Returns ``{"count", "term", "level"}``. Raises
+    ``SectionsValidationError`` if the export parses to zero courses (the shared
+    catalog is left untouched), or ``TimeoutError`` / ``RuntimeError`` on login
+    or navigation failure.
+    """
+
+    def _cb(status: str) -> None:
+        if progress_cb is not None:
+            progress_cb(status)
+
+    term_v = (term or os.environ.get(_TERM_ENV) or default_term_name()).strip()
+    level_v = (level or default_academic_level()).strip()
+    url_v = (
+        task_url if task_url is not None else os.environ.get(_SECTIONS_URL_ENV) or ""
+    ).strip() or None
+
+    _cb("pending")
+    data = _export_sections_bytes(
+        term=term_v,
+        level=level_v,
+        task_url=url_v,
+        profile_dir=profile_dir or PROFILE_DIR,
+        progress_cb=progress_cb,
+    )
+
+    _cb("validating")
+    with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tf:
+        tmp = Path(tf.name)
+        tmp.write_bytes(data)
+    try:
+        n = validate_sections_xlsx(tmp)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+    _cb("writing")
+    atomic_write_xlsx(DEST_XLSX, data)
+    # In-process only; the API process clears its own caches after the job.
+    clear_schedule_caches()
+    return {"count": n, "term": term_v, "level": level_v}
+
+
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 
@@ -384,21 +492,13 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     task_url = (os.environ.get(_SECTIONS_URL_ENV) or "").strip() or None
 
-    context = None
     try:
-        context, page = wb.launch(PROFILE_DIR)
-        page = wb.wait_for_login(page)
-        print("Exporting Find Course Sections to Excel…", flush=True)
-
-        def _navigate(pg: Any) -> None:
-            navigate_find_course_sections(
-                pg,
-                term=args.term.strip(),
-                level=args.level.strip(),
-                task_url=task_url,
-            )
-
-        data = wb.export_to_excel(page, _navigate)
+        data = _export_sections_bytes(
+            term=args.term.strip(),
+            level=args.level.strip(),
+            task_url=task_url,
+            profile_dir=PROFILE_DIR,
+        )
 
         with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tf:
             tmp = Path(tf.name)
@@ -438,12 +538,6 @@ def main(argv: list[str] | None = None) -> int:
     except OSError as exc:
         print(f"ERROR: failed to write catalog — {exc}", file=sys.stderr, flush=True)
         return EXIT_WRITE
-    finally:
-        if context is not None:
-            try:
-                context.close()
-            except Exception:  # noqa: BLE001
-                pass
 
 
 if __name__ == "__main__":

--- a/project/tests/conftest.py
+++ b/project/tests/conftest.py
@@ -52,6 +52,7 @@ def _reset_rate_limiter():
                     "four_year_plan": generous,
                     "slot_suggest": generous,
                     "workday_sync": generous,
+                    "workday_sync_sections": generous,
                 }
             )
         )

--- a/project/tests/test_rate_limit.py
+++ b/project/tests/test_rate_limit.py
@@ -192,6 +192,7 @@ def test_default_limits_match_review_spec():
         "four_year_plan",
         "slot_suggest",
         "workday_sync",
+        "workday_sync_sections",
     }
     assert DEFAULT_LIMITS["plan"].per_minute_ip == 10
     assert DEFAULT_LIMITS["plan"].per_minute_user == 20

--- a/project/tests/test_workday_pull_progress.py
+++ b/project/tests/test_workday_pull_progress.py
@@ -116,7 +116,7 @@ def test_ensure_on_task_prefers_home_academics_app(monkeypatch):
     page.goto = pytest.fail  # type: ignore[attr-defined]
     page.wait_for_timeout = lambda *_a, **_k: None  # type: ignore[attr-defined]
     monkeypatch.setattr(wpp, "_finalize_report_page", lambda _p: False)
-    monkeypatch.setattr(wpp, "_wait_for_workday_content", lambda _p: None)
+    monkeypatch.setattr(wpp, "_wait_for_workday_content", lambda *_a, **_k: None)
     wpp._ensure_on_task(page)
     assert order == ["home"]
 
@@ -127,12 +127,45 @@ def test_ensure_on_task_raises_when_navigation_fails(monkeypatch):
     page.wait_for_load_state = lambda *_a, **_k: None  # type: ignore[attr-defined]
     page.wait_for_timeout = lambda *_a, **_k: None  # type: ignore[attr-defined]
     monkeypatch.setattr(wpp, "_finalize_report_page", lambda _p: False)
-    monkeypatch.setattr(wpp, "_wait_for_workday_content", lambda _p: None)
+    monkeypatch.setattr(wpp, "_wait_for_workday_content", lambda *_a, **_k: None)
     monkeypatch.setattr(wpp, "_try_home_academics_app", lambda _p: False)
     monkeypatch.setattr(wpp, "_try_sidebar_menu", lambda _p: False)
     monkeypatch.setattr(wpp, "_try_search_for_report", lambda _p: False)
     with pytest.raises(RuntimeError, match="View My Academic Progress"):
         wpp._ensure_on_task(page, task_url=wpp.TASK_URL)
+
+
+# ── Conditional render wait (the perf fix) ───────────────────────────────────
+
+
+def _wait_probe_page():
+    timeouts: list[int] = []
+    page = SimpleNamespace(
+        wait_for_load_state=lambda *_a, **_k: None,
+        wait_for_timeout=lambda ms: timeouts.append(ms),
+    )
+    return page, timeouts
+
+
+def test_wait_returns_immediately_when_ready():
+    """The win: stop the moment the next view is painted, don't sleep the cap."""
+    page, timeouts = _wait_probe_page()
+    wpp._wait_for_workday_content(page, ready=lambda: True)
+    assert timeouts == []  # never paused — ready on the first check
+
+
+def test_wait_falls_back_to_fixed_pause_without_ready():
+    """No readiness check given → preserve the legacy fixed RENDER_WAIT_MS pause."""
+    page, timeouts = _wait_probe_page()
+    wpp._wait_for_workday_content(page)
+    assert timeouts == [wpp.RENDER_WAIT_MS]
+
+
+def test_wait_caps_when_never_ready():
+    """Unmet readiness must still wait out the cap — no worse than the old behavior."""
+    page, timeouts = _wait_probe_page()
+    wpp._wait_for_workday_content(page, ready=lambda: False)
+    assert sum(timeouts) >= wpp.RENDER_WAIT_MS
 
 
 # ── CLI / upload (mocked) ─────────────────────────────────────────────────────

--- a/project/tests/test_workday_router.py
+++ b/project/tests/test_workday_router.py
@@ -92,3 +92,54 @@ def test_sync_and_status_scoped_to_user(db_path, monkeypatch):
 
         other = client.get(f"/api/workday/status/{job_id}", params={"user_id": other_uid})
         assert other.status_code == 404
+
+
+def test_sync_sections_requires_auth(db_path, monkeypatch):
+    with _client(monkeypatch, db_path=db_path, memory_dir=_memory_dir(db_path)) as client:
+        res = client.post("/api/workday/sync-sections", json={"user_id": ""})
+    assert res.status_code == 401
+
+
+def test_sync_sections_reports_catalog_count(db_path, monkeypatch):
+    import sqlite3
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO users (google_sub, email) VALUES (?, ?)",
+        ("sub-sections-a", "sections-a@scu.edu"),
+    )
+    conn.commit()
+    uid = str(
+        conn.execute("SELECT id FROM users WHERE email = ?", ("sections-a@scu.edu",)).fetchone()[0]
+    )
+    conn.close()
+
+    def fake_pull(*, progress_cb=None, **kwargs):
+        if progress_cb:
+            progress_cb("writing")
+        return {"count": 5, "term": "Fall 2026", "level": "Undergraduate"}
+
+    import scripts.workday_pull_sections as wps
+
+    monkeypatch.setattr(wps, "pull_course_sections", fake_pull)
+
+    with _client(monkeypatch, db_path=db_path, memory_dir=_memory_dir(db_path)) as client:
+        start = client.post("/api/workday/sync-sections", json={"user_id": uid})
+        assert start.status_code == 200
+        job_id = start.json()["job_id"]
+
+        import time
+
+        for _ in range(30):
+            st = client.get(f"/api/workday/status/{job_id}", params={"user_id": uid})
+            assert st.status_code == 200
+            body = st.json()
+            if body["status"] in ("done", "error"):
+                break
+            time.sleep(0.05)
+        else:
+            raise AssertionError("job did not finish")
+
+        assert body["status"] == "done", body
+        assert body.get("count") == 5
+        assert body.get("term") == "Fall 2026"

--- a/project/web/src/api/client.ts
+++ b/project/web/src/api/client.ts
@@ -54,6 +54,22 @@ export async function startWorkdaySync(user_id: string): Promise<{ job_id: strin
   return data as { job_id: string };
 }
 
+/**
+ * Start a shared Find Course Sections catalog pull. Overwrites the catalog for
+ * all users, so callers should confirm with the user first. Poll with
+ * {@link pollWorkdayStatus} (the same job store); the done job carries `count`.
+ */
+export async function startWorkdaySectionsSync(user_id: string): Promise<{ job_id: string }> {
+  const res = await fetch(`${API_BASE}/workday/sync-sections`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(errFromBody(data));
+  return data as { job_id: string };
+}
+
 export async function pollWorkdayStatus(job_id: string, user_id: string) {
   const q = new URLSearchParams({ user_id });
   const res = await fetch(
@@ -66,6 +82,10 @@ export async function pollWorkdayStatus(job_id: string, user_id: string) {
     label: string;
     missing_details?: unknown[];
     parsed_rows?: unknown[];
+    // Find Course Sections jobs report the catalog size + term instead.
+    count?: number;
+    term?: string;
+    level?: string;
     error?: string;
   };
 }

--- a/project/web/src/components/ChatPanel.tsx
+++ b/project/web/src/components/ChatPanel.tsx
@@ -11,6 +11,7 @@ import {
   generatePlan,
   getWorkdayPullAvailable,
   pollWorkdayStatus,
+  startWorkdaySectionsSync,
   startWorkdaySync,
   transcribeAudio,
   uploadTranscript,
@@ -165,6 +166,13 @@ export function ChatPanel({
     phase: "idle" | "active" | "done" | "error";
   }>({ syncing: false, label: "", phase: "idle" });
   const workdayPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Shared Find Course Sections catalog sync (separate from the per-user transcript pull).
+  const [catalogStatus, setCatalogStatus] = useState<{
+    syncing: boolean;
+    label: string;
+    phase: "idle" | "active" | "done" | "error";
+  }>({ syncing: false, label: "", phase: "idle" });
+  const catalogPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const hasUserInput = messages.some((m) => m.role === "user");
   const canDropFiles = !hasUserInput;
@@ -207,6 +215,10 @@ export function ChatPanel({
       if (workdayPollRef.current) {
         clearInterval(workdayPollRef.current);
         workdayPollRef.current = null;
+      }
+      if (catalogPollRef.current) {
+        clearInterval(catalogPollRef.current);
+        catalogPollRef.current = null;
       }
     };
   }, []);
@@ -304,6 +316,75 @@ export function ChatPanel({
     setFileUploaded,
     setMessages,
   ]);
+
+  const startCatalogPull = useCallback(async () => {
+    if (catalogStatus.syncing || !userId || !workdayPullAvailable) return;
+    const ok = window.confirm(
+      "Refresh the shared course catalog (Find Course Sections) from Workday?\n\n" +
+        "This opens a browser for you to log in (SSO + Duo), then replaces the " +
+        "catalog for everyone. Only do this when a new term's schedule is posted.",
+    );
+    if (!ok) return;
+    if (typeof Notification !== "undefined" && Notification.permission === "default") {
+      void Notification.requestPermission();
+    }
+    setCatalogStatus({ syncing: true, label: "Starting browser…", phase: "active" });
+
+    let jobId: string;
+    try {
+      const res = await startWorkdaySectionsSync(userId);
+      jobId = res.job_id;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setCatalogStatus({ syncing: false, label: `Failed to start: ${msg}`, phase: "error" });
+      return;
+    }
+
+    catalogPollRef.current = setInterval(async () => {
+      try {
+        const job = await pollWorkdayStatus(jobId, userId);
+        setCatalogStatus({
+          syncing: job.status !== "done" && job.status !== "error",
+          label: job.label ?? job.status,
+          phase:
+            job.status === "done" ? "done" : job.status === "error" ? "error" : "active",
+        });
+
+        if (job.status === "done") {
+          clearInterval(catalogPollRef.current!);
+          catalogPollRef.current = null;
+          const count = typeof job.count === "number" ? job.count : 0;
+          const term = job.term ? ` for ${job.term}` : "";
+          setMessages((m) => [
+            ...m,
+            {
+              id: `a-${Date.now()}`,
+              role: "assistant",
+              content: `Course catalog updated${term} — ${count} sections available. The "+ Add course" list now reflects the latest schedule.`,
+            },
+          ]);
+          focusPlannerAfterWorkdaySync();
+        } else if (job.status === "error") {
+          clearInterval(catalogPollRef.current!);
+          catalogPollRef.current = null;
+          setMessages((m) => [
+            ...m,
+            {
+              id: `a-${Date.now()}`,
+              role: "assistant",
+              content: `Course catalog sync failed: ${job.error ?? "Unknown error"}`,
+            },
+          ]);
+          focusPlannerAfterWorkdaySync();
+        }
+      } catch {
+        clearInterval(catalogPollRef.current!);
+        catalogPollRef.current = null;
+        setCatalogStatus({ syncing: false, label: "Connection lost", phase: "error" });
+        focusPlannerAfterWorkdaySync();
+      }
+    }, 2000);
+  }, [userId, workdayPullAvailable, catalogStatus.syncing, setMessages]);
 
   const sendText = useCallback(async (text: string) => {
     const trimmed = text.trim();
@@ -665,6 +746,39 @@ export function ChatPanel({
           </div>
         )}
 
+        {catalogStatus.phase !== "idle" && (
+          <div
+            className={`mb-2 flex items-center gap-2 rounded-md px-3 py-2 text-xs font-medium ${
+              catalogStatus.phase === "error"
+                ? "bg-red-50 text-red-700"
+                : catalogStatus.phase === "done"
+                  ? "bg-emerald-50 text-emerald-700"
+                  : "bg-blue-50 text-blue-700"
+            }`}
+          >
+            {catalogStatus.syncing && (
+              <span className="inline-block h-2 w-2 shrink-0 rounded-full bg-blue-500 animate-pulse" />
+            )}
+            <span className="flex-1 truncate">
+              {catalogStatus.label ? `Catalog: ${catalogStatus.label}` : ""}
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                if (catalogPollRef.current) {
+                  clearInterval(catalogPollRef.current);
+                  catalogPollRef.current = null;
+                }
+                setCatalogStatus({ syncing: false, label: "", phase: "idle" });
+              }}
+              className="shrink-0 rounded px-1.5 py-0.5 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-800"
+              title={catalogStatus.syncing ? "Dismiss status (browser may still be open)" : "Dismiss"}
+            >
+              ✕
+            </button>
+          </div>
+        )}
+
         {/* Voice status bar */}
         {voiceStatus !== "idle" && (
           <div
@@ -730,6 +844,25 @@ export function ChatPanel({
                 {workdayStatus.syncing ? <SpinnerIcon /> : <WorkdayIcon />}
               </button>
             )}
+            {workdayPullAvailable && userId && (
+              <button
+                type="button"
+                onClick={() => void startCatalogPull()}
+                disabled={catalogStatus.syncing}
+                title={
+                  catalogStatus.syncing
+                    ? "Syncing course catalog…"
+                    : "Sync course catalog from Workday (shared — refreshes Find Course Sections for everyone)"
+                }
+                className={`rounded-md p-2 transition ${
+                  catalogStatus.syncing
+                    ? "cursor-wait bg-blue-100 text-blue-500"
+                    : "text-neutral-500 hover:bg-neutral-100 hover:text-blue-600"
+                }`}
+              >
+                {catalogStatus.syncing ? <SpinnerIcon /> : <CatalogIcon />}
+              </button>
+            )}
             <button
               type="button"
               onClick={() => void toggleVoice()}
@@ -780,6 +913,26 @@ function WorkdayIcon({ size = 20 }: { size?: number }) {
       />
       <path
         d="M8 10h8M8 14h5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function CatalogIcon({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden>
+      <rect x="3" y="4" width="18" height="17" rx="2" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M3 9h18M8 2v4M16 2v4"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      <path
+        d="M7 13h4M7 17h7"
         stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"


### PR DESCRIPTION
## Summary
Merges two Claude branches onto the latest `main`. The three change sets touch **non-overlapping files**, so the merge was clean (no conflicts).

- **`frosty-leakey` — Workday nav speedup**: replace the fixed 4s `RENDER_WAIT_MS` sleep after every navigation hop with "continue as soon as the next view paints, capped at 4s". Happy-path nav waiting drops from ~26s toward ~5–10s; when an element isn't found it still waits out the full cap, so the slow path is unchanged.
- **`jovial-nightingale` — in-app catalog sync**: in-app sync for the shared Find Course Sections catalog (workday router + rate limit + ChatPanel/client frontend).
- Rebuilt on `origin/main` (first-login carousel, Data Disclosure, export tutorial text, Sprint 2 retro).

## Test plan
- [x] Full Python suite: **416 passed, 9 skipped** (skips are no-browser Playwright cases)
- [ ] Frontend: chat panel + first-login carousel render together
- [ ] Manual: run a Workday sync and confirm navigation is noticeably faster
- [ ] Manual: confirm in-app Find Course Sections catalog sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)