### PR TITLE
fix(planner): pin Senior Design sections in truncated major bulletins

### DIFF
--- a/project/course_planner/utils/major_requirements.py
+++ b/project/course_planner/utils/major_requirements.py
@@ -101,20 +101,76 @@ def _markdown_body_without_frontmatter(text: str) -> str:
     return text
 
 
+def _extract_senior_design_sections(body: str, sd_codes: list[str]) -> str:
+    """Per-course catalog blocks for SD codes + the trailing SD sequence note."""
+    chunks: list[str] = []
+    seen: set[str] = set()
+    for code in sd_codes:
+        if not code or code in seen:
+            continue
+        seen.add(code)
+        pat = re.compile(
+            rf"###\s+{re.escape(code)}\s+—[\s\S]*?(?=\n\s*---\s*\n|\n##\s|\Z)",
+            re.IGNORECASE,
+        )
+        m = pat.search(body)
+        if m:
+            chunks.append(m.group(0).strip())
+    sd_section = re.search(
+        r"##\s+Senior Design[\s\S]*?(?=\n##\s|\Z)",
+        body,
+        re.IGNORECASE,
+    )
+    if sd_section:
+        chunks.append(sd_section.group(0).strip())
+    return "\n\n---\n\n".join(chunks).strip()
+
+
 def load_major_markdown_excerpt(major_id: str, *, max_chars: int = _MARKDOWN_MAX_CHARS) -> str:
-    """Trimmed bulletin text for LLM prompts (requirements + prerequisite catalog)."""
+    """Trimmed bulletin text for LLM prompts (requirements + prerequisite catalog).
+
+    Senior-Design catalog entries and the trailing ``## Senior Design sequence``
+    note live at the bottom of long bulletins, so naive truncation drops them.
+    They are pinned to the tail of the excerpt so the LLM always sees the
+    final-year sequencing rule.
+    """
     raw = load_major_markdown(major_id)
     if not raw:
         return ""
     body = _markdown_body_without_frontmatter(raw)
-    # Prefer degree requirements + prerequisite sections; drop very long tail if needed.
+
+    spec = (load_major_catalog().get("majors") or {}).get(major_id) or {}
+    sd_codes = [
+        _normalize_code(str(c))
+        for c in (spec.get("senior_design_sequence") or [])
+    ]
+    sd_codes = [c for c in sd_codes if c]
+
     if len(body) <= max_chars:
         return body.strip()
+
     cut = body[:max_chars]
     last_hr = cut.rfind("\n---\n")
     if last_hr > max_chars // 2:
         cut = cut[:last_hr]
-    return cut.strip() + "\n\n(… bulletin excerpt truncated …)\n"
+
+    truncated = cut.strip() + "\n\n(… bulletin excerpt truncated …)\n"
+
+    pinned = _extract_senior_design_sections(body, sd_codes) if sd_codes else ""
+    if not pinned:
+        return truncated
+
+    missing_catalog = any(f"### {code} " not in cut for code in sd_codes)
+    missing_rule = "## Senior Design" not in cut
+    if not (missing_catalog or missing_rule):
+        return truncated
+
+    return (
+        truncated
+        + "\n--- Senior Design sections (always preserved) ---\n\n"
+        + pinned
+        + "\n"
+    )
 
 
 def _parse_prereq_codes_from_text(text: str) -> list[list[str]]:

--- a/project/tests/test_major_requirements.py
+++ b/project/tests/test_major_requirements.py
@@ -8,6 +8,7 @@ from utils.major_requirements import (
     detect_major_detailed,
     enforce_senior_design_in_final_quarters,
     infer_academic_stage,
+    load_major_markdown_excerpt,
     next_senior_design_course,
     prerequisites_met,
     remaining_major_courses,
@@ -81,6 +82,19 @@ def test_remaining_major_courses_excludes_completed() -> None:
     remaining = remaining_major_courses("csen", completed, [])
     assert "CSEN 10" not in remaining
     assert "CSEN 194" in remaining
+
+
+def test_excerpt_pins_senior_design_sections_when_bulletin_truncated() -> None:
+    # CSEN bulletin is ~22KB; default excerpt cap is 10KB, so SD catalog
+    # entries and the trailing "## Senior Design sequence" rule live past the
+    # cut. They must still reach the LLM prompt.
+    text = load_major_markdown_excerpt("csen")
+    assert "(… bulletin excerpt truncated …)" in text
+    assert "### CSEN 194 —" in text
+    assert "### CSEN 195 —" in text
+    assert "### CSEN 196 —" in text
+    assert "## Senior Design sequence" in text
+    assert "one course per quarter in the final year" in text
 
 
 def test_enforce_senior_design_moves_to_last_three_quarters() -> None:


### PR DESCRIPTION
## 问题
CSEN 的 bulletin markdown 约 22KB，但发给 LLM 的 excerpt 截断在 10KB。结果 `CSEN 192/194/195/196` 的目录条目和文件末尾的 `## Senior Design sequence` 规则（"final year 每学期一门，194 → 195 → 196"）全被截掉，planner 看不到，只能给出"找学术顾问"这种废话。

## 修复
- 新增 `_extract_senior_design_sections()`：抽取 `senior_design_sequence` 里每门课的目录块 + 末尾 SD 规则段。
- `load_major_markdown_excerpt()` 在截断后把这些段"钉"在 excerpt 末尾，确保 LLM 始终看到 final-year 排序规则。
- 非工程专业（无 `senior_design_sequence`）不受影响。

## 验证
- csen / ecen / mech / ceng 四个工程专业 excerpt 现均含完整 SD 段。
- 新增回归测试 `test_excerpt_pins_senior_design_sections_when_bulletin_truncated`。
- 全部 678 个测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)